### PR TITLE
feat: allow injecting manual query client

### DIFF
--- a/examples/fasq_example/lib/main.dart
+++ b/examples/fasq_example/lib/main.dart
@@ -1,17 +1,27 @@
 import 'package:fasq/fasq.dart';
 import 'package:flutter/material.dart';
+
 import 'core/screens/core_examples_screen.dart';
 
+final QueryClient _queryClient = QueryClient(
+  config: const CacheConfig(
+    defaultCacheTime: Duration(minutes: 10),
+  ),
+);
+
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp(client: _queryClient));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.client});
+
+  final QueryClient client;
 
   @override
   Widget build(BuildContext context) {
     return QueryClientProvider(
+      client: client,
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
         title: 'FASQ Examples',

--- a/packages/fasq/README.md
+++ b/packages/fasq/README.md
@@ -859,15 +859,18 @@ QueryBuilder<String>(
 Configure security features globally:
 
 ```dart
-QueryClientProvider(
+final client = QueryClient(
   config: CacheConfig(
     defaultStaleTime: Duration(minutes: 5),
     defaultCacheTime: Duration(minutes: 10),
   ),
   persistenceOptions: PersistenceOptions(
     enabled: true,
-    encryptionKey: 'your-encryption-key',
   ),
+);
+
+QueryClientProvider(
+  client: client,
   child: MyApp(),
 )
 


### PR DESCRIPTION
## Summary
- let QueryClientProvider reuse an externally created client
- document manual client setup in README
- showcase manual wiring in example app