### PR TITLE
fix: wait for persistence initialization before creating queries

### DIFF
--- a/packages/fasq/lib/src/core/query_client.dart
+++ b/packages/fasq/lib/src/core/query_client.dart
@@ -352,6 +352,14 @@ class QueryClient with WidgetsBindingObserver {
   /// Useful for direct cache access in tests or advanced use cases.
   QueryCache get cache => _cache;
 
+  /// Gets the persistence initialization future.
+  ///
+  /// Use this to wait for persisted cache entries to be loaded
+  /// before creating queries. This ensures queries can use cached
+  /// data immediately instead of making unnecessary network requests.
+  Future<void> get persistenceInitialization =>
+      _cache.persistenceInitialization;
+
   /// The isolate pool for heavy computation tasks.
   IsolatePool get isolatePool => _isolatePool;
 

--- a/packages/fasq/lib/src/widgets/query_builder.dart
+++ b/packages/fasq/lib/src/widgets/query_builder.dart
@@ -88,8 +88,11 @@ class _QueryBuilderState<T> extends State<QueryBuilder<T>> {
     _initializeQuery();
   }
 
-  void _initializeQuery() {
+  Future<void> _initializeQuery() async {
     final client = _client ?? QueryClient();
+
+    await client.persistenceInitialization;
+
     final query = client.getQuery<T>(
       widget.queryKey,
       widget.queryFn,


### PR DESCRIPTION
## Problem

When persistence is enabled, queries were being created and started fetching before persisted cache entries were loaded from disk. This caused a race condition where:

1. QueryCache starts `_initializePersistence()` asynchronously
2. UI builds → QueryBuilder creates queries immediately  
3. Query.fetch() checks cache.get() → returns null (persistence still loading)
4. Query goes to loading state → makes network request
5. Later, `_loadPersistedEntries()` finishes, but it's too late

**Result**: On every app restart, queries would show loading states and make unnecessary network requests even though cached data existed.

## Solution

1. **Exposed persistence initialization**: Added `persistenceInitialization` getter to `QueryClient` to expose the cache's persistence initialization future.

2. **Made QueryBuilder wait**: Modified `QueryBuilder._initializeQuery()` to await persistence initialization before creating queries. This ensures persisted cache entries are loaded into memory before queries check the cache.

## How It Works

### Before Fix
- Queries created immediately → cache empty → network request → loading state

### After Fix  
- Queries wait for persistence → cache populated → cached data found → no network request → instant data display

## Expected Behavior

**First App Open**:
- Persistence initializes → no persisted data exists
- Queries wait for persistence (instant, no data)
- Queries fetch from network → data is cached and persisted

**Subsequent App Opens**:
- Persistence initializes → loads persisted entries into `_entries` map
- Queries wait for persistence (loads data from disk)
- `getQuery()` finds cached entry → query created with `initialEntry`
- `fetch()` checks cache → finds fresh/stale data → **no network request**
- UI shows cached data immediately (no loading spinner)

## Backward Compatibility

The fix is fully backward compatible:
- If persistence is not enabled, `persistenceInitialization` returns an already-completed future
- No performance impact when persistence is disabled
- Existing code continues to work without changes

## Testing

To verify the fix:
1. Enable persistence with `PersistenceOptions(enabled: true)`
2. Open app → verify network requests on first load
3. Close app completely
4. Reopen app → verify **NO network requests**, data loads instantly from cache