### PR TITLE
feat(sync): add durable mutation contracts

### DIFF
--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -31,6 +31,7 @@ export 'src/mutation/mutation_status.dart';
 export 'src/mutation/network_status.dart';
 export 'src/mutation/offline_queue.dart';
 export 'src/mutation/sync_engine/kahn_dag.dart';
+export 'src/mutation/sync_engine/mutation_contracts.dart';
 export 'src/observability/error/error_context.dart';
 export 'src/observability/error/error_reporter.dart';
 export 'src/observability/logging/fasq_logger.dart';

--- a/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
@@ -1,0 +1,193 @@
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_json.dart';
+
+/// Encodes and decodes one typed mutation variable model.
+abstract interface class MutationCodec<TVariables> {
+  /// Encodes variables into JSON-safe data.
+  Object? encode(TVariables variables);
+
+  /// Decodes JSON-safe data into typed variables.
+  TVariables decode(Object? payload);
+}
+
+/// Codec backed by explicit JSON encode/decode functions.
+class JsonMutationCodec<TVariables> implements MutationCodec<TVariables> {
+  /// Creates a JSON mutation codec.
+  const JsonMutationCodec({required this.encoder, required this.decoder});
+
+  /// Typed encoder supplied by the application.
+  final Object? Function(TVariables variables) encoder;
+
+  /// Typed decoder supplied by the application.
+  final TVariables Function(Object? payload) decoder;
+
+  @override
+  Object? encode(TVariables variables) {
+    final payload = encoder(variables);
+    validateJsonValue(payload);
+    return payload;
+  }
+
+  @override
+  TVariables decode(Object? payload) {
+    validateJsonValue(payload);
+    try {
+      return decoder(payload);
+    } on MutationContractException {
+      rethrow;
+    } on Object {
+      throw const InvalidMutationPayloadException(
+        'Mutation payload could not be decoded',
+      );
+    }
+  }
+}
+
+/// Registry of typed variable codecs keyed by versioned MutationKey.
+class MutationCodecRegistry {
+  final Map<MutationKey, _ErasedMutationCodec<Object?>> _codecs = {};
+
+  /// Registers a codec for [key].
+  void register<TVariables>(MutationKey key, MutationCodec<TVariables> codec) {
+    if (_codecs.containsKey(key)) {
+      throw DuplicateMutationRegistrationException(key.key);
+    }
+    _codecs[key] = _ErasedMutationCodec<TVariables>(codec);
+  }
+
+  /// Returns whether a codec exists for [key].
+  bool contains(MutationKey key) => _codecs.containsKey(key);
+
+  /// Encodes variables for [key].
+  Object? encode(MutationKey key, Object? variables) {
+    final codec = _codecs[key];
+    if (codec == null) throw UnknownMutationKeyException(key.key);
+    return codec.encode(variables);
+  }
+
+  /// Decodes persisted variables for [key].
+  Object? decode(MutationKey key, Object? payload) {
+    final codec = _codecs[key];
+    if (codec == null) throw UnknownMutationKeyException(key.key);
+    return codec.decode(payload);
+  }
+
+  /// Returns the registered keys in insertion order.
+  List<MutationKey> get registeredKeys => List.unmodifiable(_codecs.keys);
+
+  @override
+  String toString() => 'MutationCodecRegistry(keys: ${_codecs.keys})';
+}
+
+/// Runtime-only registration of a typed codec and async executor.
+class MutationRegistrationRegistry {
+  final Map<MutationKey, _RegisteredMutation<Object?, Object?>> _registrations =
+      {};
+
+  /// Registers a mutation executor and its variable codec.
+  void register<TData, TVariables>({
+    required MutationKey key,
+    required MutationCodec<TVariables> codec,
+    required Future<TData> Function(TVariables variables) execute,
+    AuthPolicy authPolicy = AuthPolicy.none,
+  }) {
+    if (_registrations.containsKey(key)) {
+      throw DuplicateMutationRegistrationException(key.key);
+    }
+    _registrations[key] = _RegisteredMutation<TData, TVariables>(
+      key: key,
+      codec: codec,
+      executeTyped: execute,
+      authPolicy: authPolicy,
+    );
+  }
+
+  /// Returns whether an executor is registered for [key].
+  bool contains(MutationKey key) => _registrations.containsKey(key);
+
+  /// Encodes variables using the runtime registration for [key].
+  Object? encodeVariables(MutationKey key, Object? variables) {
+    final registration = _registrations[key];
+    if (registration == null) throw UnknownMutationKeyException(key.key);
+    return registration.encode(variables);
+  }
+
+  /// Decodes variables using the runtime registration for [key].
+  Object? decodeVariables(MutationKey key, Object? payload) {
+    final registration = _registrations[key];
+    if (registration == null) throw UnknownMutationKeyException(key.key);
+    return registration.decode(payload);
+  }
+
+  /// Executes a registered mutation with decoded persisted variables.
+  Future<Object?> execute(MutationKey key, Object? payload) async {
+    final registration = _registrations[key];
+    if (registration == null) throw UnknownMutationKeyException(key.key);
+    return registration.execute(payload);
+  }
+
+  /// Returns the auth policy for [key].
+  AuthPolicy authPolicyFor(MutationKey key) {
+    final registration = _registrations[key];
+    if (registration == null) throw UnknownMutationKeyException(key.key);
+    return registration.authPolicy;
+  }
+
+  /// Returns the currently registered keys.
+  List<MutationKey> get registeredKeys =>
+      List.unmodifiable(_registrations.keys);
+}
+
+class _ErasedMutationCodec<TVariables> {
+  const _ErasedMutationCodec(this._codec);
+
+  final MutationCodec<TVariables> _codec;
+
+  Object? encode(Object? variables) {
+    if (variables is! TVariables) {
+      throw InvalidMutationPayloadException(
+        'Variables have type ${variables.runtimeType}, expected $TVariables',
+      );
+    }
+    return _codec.encode(variables);
+  }
+
+  Object? decode(Object? payload) => _codec.decode(payload);
+}
+
+class _RegisteredMutation<TData, TVariables> {
+  const _RegisteredMutation({
+    required this.key,
+    required this.codec,
+    required this.executeTyped,
+    required this.authPolicy,
+  });
+
+  final MutationKey key;
+  final MutationCodec<TVariables> codec;
+  final Future<TData> Function(TVariables variables) executeTyped;
+  final AuthPolicy authPolicy;
+
+  Object? encode(Object? variables) {
+    if (variables is! TVariables) {
+      throw InvalidMutationPayloadException(
+        'Variables have type ${variables.runtimeType}, expected $TVariables',
+      );
+    }
+    return codec.encode(variables);
+  }
+
+  Object? decode(Object? payload) => codec.decode(payload);
+
+  Future<Object?> execute(Object? payload) async {
+    final variables = decode(payload);
+    if (variables is! TVariables) {
+      throw InvalidMutationPayloadException(
+        'Decoded variables have type ${variables.runtimeType}, '
+        'expected $TVariables',
+      );
+    }
+    return executeTyped(variables);
+  }
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
@@ -81,6 +81,9 @@ class MutationCodecRegistry {
 }
 
 /// Runtime-only registration of a typed codec and async executor.
+///
+/// Registered function must be same logical function used for immediate
+/// mutation execution. It is not a second offline-only executor.
 class MutationRegistrationRegistry {
   final Map<MutationKey, _RegisteredMutation<Object?, Object?>> _registrations =
       {};
@@ -89,7 +92,7 @@ class MutationRegistrationRegistry {
   void register<TData, TVariables>({
     required MutationKey key,
     required MutationCodec<TVariables> codec,
-    required Future<TData> Function(TVariables variables) execute,
+    required Future<TData> Function(TVariables variables) mutationFn,
     AuthPolicy authPolicy = AuthPolicy.none,
   }) {
     if (_registrations.containsKey(key)) {
@@ -98,13 +101,20 @@ class MutationRegistrationRegistry {
     _registrations[key] = _RegisteredMutation<TData, TVariables>(
       key: key,
       codec: codec,
-      executeTyped: execute,
+      mutationFn: mutationFn,
       authPolicy: authPolicy,
     );
   }
 
   /// Returns whether an executor is registered for [key].
   bool contains(MutationKey key) => _registrations.containsKey(key);
+
+  /// Returns runtime registration readiness for [key].
+  MutationRegistrationReadiness readinessFor(MutationKey key) {
+    return contains(key)
+        ? MutationRegistrationReadiness.ready
+        : MutationRegistrationReadiness.missing;
+  }
 
   /// Encodes variables using the runtime registration for [key].
   Object? encodeVariables(MutationKey key, Object? variables) {
@@ -160,13 +170,13 @@ class _RegisteredMutation<TData, TVariables> {
   const _RegisteredMutation({
     required this.key,
     required this.codec,
-    required this.executeTyped,
+    required this.mutationFn,
     required this.authPolicy,
   });
 
   final MutationKey key;
   final MutationCodec<TVariables> codec;
-  final Future<TData> Function(TVariables variables) executeTyped;
+  final Future<TData> Function(TVariables variables) mutationFn;
   final AuthPolicy authPolicy;
 
   Object? encode(Object? variables) {
@@ -188,6 +198,15 @@ class _RegisteredMutation<TData, TVariables> {
         'expected $TVariables',
       );
     }
-    return executeTyped(variables);
+    return mutationFn(variables);
   }
+}
+
+/// Runtime readiness of a mutation codec and executor registration.
+enum MutationRegistrationReadiness {
+  /// No codec and executor are registered for the key.
+  missing,
+
+  /// Codec and executor are available for runtime use.
+  ready,
 }

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_errors.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_errors.dart
@@ -1,0 +1,100 @@
+/// Categories used to classify expected mutation outcomes.
+enum MutationFailureCategory {
+  /// Network or local connectivity failure.
+  connectivity,
+
+  /// Request or operation exceeded its time budget.
+  timeout,
+
+  /// Adapter or service rate limit was reached.
+  rateLimit,
+
+  /// Credentials are missing, expired, or invalid.
+  authentication,
+
+  /// Current identity lacks permission for the operation.
+  authorization,
+
+  /// Server or local state conflicts with the operation.
+  conflict,
+
+  /// Variables or result payload failed validation.
+  payload,
+
+  /// Domain operation rejected the requested business action.
+  business,
+
+  /// Runtime executor could not be invoked.
+  executor,
+
+  /// Durable storage operation failed.
+  storage,
+
+  /// Stored contract needs migration before execution.
+  migration,
+
+  /// Failure has no more specific normalized category.
+  unknown,
+}
+
+/// Safe, transport-agnostic failure metadata for durable operation state.
+class MutationFailure {
+  /// Creates normalized failure metadata.
+  const MutationFailure({
+    required this.category,
+    required this.messageKey,
+    required this.retryable,
+    required this.repairable,
+  });
+
+  /// Normalized failure category.
+  final MutationFailureCategory category;
+
+  /// Stable safe message key for application presentation.
+  final String messageKey;
+
+  /// Whether the adapter permits automatic retry.
+  final bool retryable;
+
+  /// Whether an explicit repair action is permitted.
+  final bool repairable;
+}
+
+/// Base error for invalid or unavailable durable mutation contracts.
+class MutationContractException implements Exception {
+  /// Creates a contract exception.
+  const MutationContractException(this.message);
+
+  /// Safe diagnostic message.
+  final String message;
+
+  @override
+  String toString() => 'MutationContractException: $message';
+}
+
+/// Raised when a mutation payload is not JSON-safe or cannot be decoded.
+class InvalidMutationPayloadException extends MutationContractException {
+  /// Creates an invalid-payload exception.
+  const InvalidMutationPayloadException(super.message);
+}
+
+/// Raised when a persisted key has no registered codec or executor.
+class UnknownMutationKeyException extends MutationContractException {
+  /// Creates an unknown-key exception.
+  const UnknownMutationKeyException(String key)
+    : super('No mutation registration exists for $key');
+}
+
+/// Raised when a duplicate registration would make replay ambiguous.
+class DuplicateMutationRegistrationException extends MutationContractException {
+  /// Creates a duplicate-registration exception.
+  const DuplicateMutationRegistrationException(String key)
+    : super('A mutation registration already exists for $key');
+}
+
+/// Raised when persisted operation state contains an unknown value.
+class UnknownMutationStateException extends MutationContractException {
+  /// Creates an unknown-state exception.
+  const UnknownMutationStateException(String state)
+    : super('Unknown mutation operation state: $state');
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_identity.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_identity.dart
@@ -1,0 +1,370 @@
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:meta/meta.dart';
+
+/// Stable, versioned logical identity for a queueable mutation.
+@immutable
+class MutationKey {
+  /// Creates a versioned mutation key.
+  factory MutationKey({
+    required String namespace,
+    required String name,
+    int version = 1,
+  }) {
+    final normalizedNamespace = _normalizeSegment(namespace, 'namespace');
+    final normalizedName = _normalizeSegment(name, 'name');
+    if (version < 1) {
+      throw ArgumentError.value(version, 'version', 'must be positive');
+    }
+    return MutationKey._(
+      namespace: normalizedNamespace,
+      name: normalizedName,
+      version: version,
+    );
+  }
+
+  const MutationKey._({
+    required this.namespace,
+    required this.name,
+    required this.version,
+  });
+
+  /// Recreates a key from its serialized fields.
+  factory MutationKey.fromJson(Map<String, Object?> json) {
+    final namespace = json['namespace'];
+    final name = json['name'];
+    final version = json['version'];
+    if (namespace is! String || name is! String || version is! int) {
+      throw const InvalidMutationPayloadException(
+        'Invalid mutation key payload',
+      );
+    }
+    return MutationKey(
+      namespace: namespace,
+      name: name,
+      version: version,
+    );
+  }
+
+  /// Namespace used to avoid collisions between application features.
+  final String namespace;
+
+  /// Stable logical mutation name.
+  final String name;
+
+  /// Schema version for this logical mutation contract.
+  final int version;
+
+  /// Canonical string key suitable for registry and storage lookup.
+  String get key => '$namespace:$name:v$version';
+
+  /// Serializes this key into a JSON-safe map.
+  Map<String, Object?> toJson() => {
+    'namespace': namespace,
+    'name': name,
+    'version': version,
+  };
+
+  @override
+  String toString() => key;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MutationKey &&
+          namespace == other.namespace &&
+          name == other.name &&
+          version == other.version;
+
+  @override
+  int get hashCode => Object.hash(namespace, name, version);
+
+  static String _normalizeSegment(String value, String fieldName) {
+    final normalized = value.trim();
+    if (normalized.isEmpty || normalized.contains(':')) {
+      throw ArgumentError.value(
+        value,
+        fieldName,
+        'must be non-empty and must not contain a colon',
+      );
+    }
+    return normalized;
+  }
+}
+
+/// Stable identifier for one durable operation occurrence.
+@immutable
+class OperationId {
+  /// Creates an operation ID.
+  factory OperationId(String value) => OperationId._(_requireValue(value));
+
+  const OperationId._(this.value);
+
+  /// Serialized identifier value.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is OperationId && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// Stable key reused across automatic retries and restarts.
+@immutable
+class IdempotencyKey {
+  /// Creates an idempotency key.
+  factory IdempotencyKey(String value) =>
+      IdempotencyKey._(_requireValue(value));
+
+  const IdempotencyKey._(this.value);
+
+  /// Serialized key value.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is IdempotencyKey && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// Identifier connecting an operation and its explicit repairs.
+@immutable
+class LineageId {
+  /// Creates a lineage ID.
+  factory LineageId(String value) => LineageId._(_requireValue(value));
+
+  const LineageId._(this.value);
+
+  /// Serialized lineage value.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is LineageId && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// Authentication policy selected by a queueable mutation.
+enum AuthPolicy {
+  /// The operation does not require an authenticated user.
+  none,
+
+  /// The operation must replay under its captured [AuthScope].
+  required,
+}
+
+/// Exact non-secret identity under which required work was queued.
+@immutable
+class AuthScope {
+  /// Creates an authentication scope.
+  factory AuthScope({
+    required String principalId,
+    required String tenantId,
+    required String authRealm,
+  }) {
+    return AuthScope._(
+      principalId: _requireValue(principalId),
+      tenantId: _requireValue(tenantId),
+      authRealm: _requireValue(authRealm),
+    );
+  }
+
+  const AuthScope._({
+    required this.principalId,
+    required this.tenantId,
+    required this.authRealm,
+  });
+
+  /// Recreates a scope from serialized fields.
+  factory AuthScope.fromJson(Map<String, Object?> json) {
+    final principalId = json['principalId'];
+    final tenantId = json['tenantId'];
+    final authRealm = json['authRealm'];
+    if (principalId is! String || tenantId is! String || authRealm is! String) {
+      throw const InvalidMutationPayloadException('Invalid auth scope payload');
+    }
+    return AuthScope(
+      principalId: principalId,
+      tenantId: tenantId,
+      authRealm: authRealm,
+    );
+  }
+
+  /// Non-secret principal identifier.
+  final String principalId;
+
+  /// Non-secret tenant or account identifier.
+  final String tenantId;
+
+  /// Non-secret authentication realm identifier.
+  final String authRealm;
+
+  /// Stable scope key for filtering and ownership checks.
+  String get scopeKey => '$authRealm:$tenantId:$principalId';
+
+  /// Serializes this scope into a JSON-safe map.
+  Map<String, Object?> toJson() => {
+    'principalId': principalId,
+    'tenantId': tenantId,
+    'authRealm': authRealm,
+  };
+
+  @override
+  String toString() => scopeKey;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AuthScope &&
+          principalId == other.principalId &&
+          tenantId == other.tenantId &&
+          authRealm == other.authRealm;
+
+  @override
+  int get hashCode => Object.hash(principalId, tenantId, authRealm);
+}
+
+/// Explicit dependency edge from a child operation to a parent operation.
+@immutable
+class MutationDependency {
+  /// Creates a dependency descriptor.
+  factory MutationDependency({
+    required OperationId parentOperationId,
+    String? parentResultPath,
+    String? childVariablePath,
+  }) {
+    return MutationDependency._(
+      parentOperationId: parentOperationId,
+      parentResultPath: _normalizeOptionalPath(parentResultPath),
+      childVariablePath: _normalizeOptionalPath(childVariablePath),
+    );
+  }
+
+  const MutationDependency._({
+    required this.parentOperationId,
+    required this.parentResultPath,
+    required this.childVariablePath,
+  });
+
+  /// Recreates a dependency from serialized fields.
+  factory MutationDependency.fromJson(Map<String, Object?> json) {
+    final parentId = json['parentOperationId'];
+    if (parentId is! String) {
+      throw const InvalidMutationPayloadException(
+        'Invalid mutation dependency payload',
+      );
+    }
+    return MutationDependency(
+      parentOperationId: OperationId(parentId),
+      parentResultPath: _optionalString(json['parentResultPath']),
+      childVariablePath: _optionalString(json['childVariablePath']),
+    );
+  }
+
+  /// Parent operation that must complete before the child can execute.
+  final OperationId parentOperationId;
+
+  /// Optional selected path from the parent result.
+  final String? parentResultPath;
+
+  /// Optional child-variable path receiving the selected parent result.
+  final String? childVariablePath;
+
+  /// Serializes this dependency into a JSON-safe map.
+  Map<String, Object?> toJson() => {
+    'parentOperationId': parentOperationId.value,
+    'parentResultPath': parentResultPath,
+    'childVariablePath': childVariablePath,
+  };
+
+  static String? _normalizeOptionalPath(String? path) {
+    final normalized = path?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
+
+  static String? _optionalString(Object? value) {
+    if (value == null) return null;
+    if (value is String) return value;
+    throw const InvalidMutationPayloadException(
+      'Dependency paths must be strings',
+    );
+  }
+}
+
+/// Explicit cache projection plan reference.
+@immutable
+class MutationProjectionDescriptor {
+  /// Creates a projection descriptor.
+  factory MutationProjectionDescriptor({
+    required String id,
+    required List<String> queryKeys,
+  }) {
+    final normalizedId = _requireValue(id);
+    final normalizedKeys = queryKeys.map(_requireValue).toList();
+    if (normalizedKeys.isEmpty) {
+      throw ArgumentError.value(queryKeys, 'queryKeys', 'must not be empty');
+    }
+    return MutationProjectionDescriptor._(
+      id: normalizedId,
+      queryKeys: List.unmodifiable(normalizedKeys),
+    );
+  }
+
+  const MutationProjectionDescriptor._({
+    required this.id,
+    required this.queryKeys,
+  });
+
+  /// Recreates a descriptor from serialized fields.
+  factory MutationProjectionDescriptor.fromJson(Map<String, Object?> json) {
+    final id = json['id'];
+    final rawKeys = json['queryKeys'];
+    if (id is! String || rawKeys is! List<Object?>) {
+      throw const InvalidMutationPayloadException(
+        'Invalid mutation projection payload',
+      );
+    }
+    return MutationProjectionDescriptor(
+      id: id,
+      queryKeys: rawKeys.map(_decodeQueryKey).toList(),
+    );
+  }
+
+  /// Stable projection plan identifier.
+  final String id;
+
+  /// Query keys explicitly affected by the plan.
+  final List<String> queryKeys;
+
+  /// Serializes this descriptor into a JSON-safe map.
+  Map<String, Object?> toJson() => {'id': id, 'queryKeys': queryKeys};
+
+  static String _decodeQueryKey(Object? value) {
+    if (value is String) return value;
+    throw const InvalidMutationPayloadException(
+      'Projection query keys must be strings',
+    );
+  }
+}
+
+String _requireValue(String value) {
+  final normalized = value.trim();
+  if (normalized.isEmpty) {
+    throw ArgumentError.value(value, 'value', 'must not be empty');
+  }
+  return normalized;
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_json.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_json.dart
@@ -1,0 +1,30 @@
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+
+/// Validates a value against durable JSON value grammar.
+void validateJsonValue(Object? value, [String path = 'value']) {
+  if (value == null || value is String || value is bool) return;
+  if (value is num) {
+    if (value is double && !value.isFinite) {
+      throw InvalidMutationPayloadException('$path must be finite');
+    }
+    return;
+  }
+  if (value is List<Object?>) {
+    for (var index = 0; index < value.length; index++) {
+      validateJsonValue(value[index], '$path[$index]');
+    }
+    return;
+  }
+  if (value is Map<Object?, Object?>) {
+    for (final entry in value.entries) {
+      if (entry.key is! String) {
+        throw InvalidMutationPayloadException('$path has a non-string key');
+      }
+      validateJsonValue(entry.value, '$path.${entry.key}');
+    }
+    return;
+  }
+  throw InvalidMutationPayloadException(
+    '$path contains unsupported type ${value.runtimeType}',
+  );
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
@@ -1,0 +1,261 @@
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_json.dart';
+import 'package:meta/meta.dart';
+
+/// Durable lifecycle state for one queued mutation operation.
+enum MutationOperationState {
+  /// Operation is persisted and eligible for scheduling.
+  pending,
+
+  /// Operation executor is currently running.
+  running,
+
+  /// Operation waits for its retry time.
+  retryScheduled,
+
+  /// Operation is paused by lifecycle or policy.
+  paused,
+
+  /// Operation cannot run until a dependency or repair is resolved.
+  blocked,
+
+  /// Operation completed successfully.
+  succeeded,
+
+  /// Operation failed permanently and needs user/application action.
+  failedTerminal,
+
+  /// Execution result is ambiguous and must not be blindly replayed.
+  unknownOutcome,
+
+  /// Operation was intentionally removed from active work.
+  discarded,
+
+  /// Stored contract version needs migration.
+  migrationRequired,
+
+  /// Durable state failed integrity checks.
+  storageCorrupt,
+}
+
+/// Parses a persisted operation state without silently accepting unknown data.
+MutationOperationState parseMutationOperationState(String value) {
+  for (final state in MutationOperationState.values) {
+    if (state.name == value) return state;
+  }
+  throw UnknownMutationStateException(value);
+}
+
+/// JSON-safe durable contract for a queued mutation operation.
+@immutable
+class MutationOperation {
+  /// Creates an operation contract.
+  factory MutationOperation({
+    required OperationId operationId,
+    required MutationKey mutationKey,
+    required Object? variables,
+    required DateTime createdAt,
+    required IdempotencyKey idempotencyKey,
+    required LineageId lineageId,
+    required AuthPolicy authPolicy,
+    required MutationOperationState state,
+    AuthScope? authScope,
+    List<MutationDependency> dependencies = const <MutationDependency>[],
+    List<MutationProjectionDescriptor> projections =
+        const <MutationProjectionDescriptor>[],
+  }) {
+    if ((authPolicy == AuthPolicy.required) != (authScope != null)) {
+      throw ArgumentError.value(
+        authScope,
+        'authScope',
+        'must be present only for required auth policy',
+      );
+    }
+    validateJsonValue(variables, 'variables');
+    return MutationOperation._(
+      operationId: operationId,
+      mutationKey: mutationKey,
+      variables: variables,
+      createdAt: createdAt,
+      idempotencyKey: idempotencyKey,
+      lineageId: lineageId,
+      authPolicy: authPolicy,
+      state: state,
+      authScope: authScope,
+      dependencies: List.unmodifiable(dependencies),
+      projections: List.unmodifiable(projections),
+    );
+  }
+
+  const MutationOperation._({
+    required this.operationId,
+    required this.mutationKey,
+    required this.variables,
+    required this.createdAt,
+    required this.idempotencyKey,
+    required this.lineageId,
+    required this.authPolicy,
+    required this.state,
+    required this.dependencies,
+    required this.projections,
+    this.authScope,
+  });
+
+  /// Recreates an operation from a validated JSON-safe map.
+  factory MutationOperation.fromJson(Map<String, Object?> json) {
+    final operationId = json['operationId'];
+    final mutationKey = json['mutationKey'];
+    final variables = json['variables'];
+    final createdAt = json['createdAt'];
+    final idempotencyKey = json['idempotencyKey'];
+    final lineageId = json['lineageId'];
+    final authPolicy = json['authPolicy'];
+    final state = json['state'];
+    if (operationId is! String ||
+        mutationKey is! Map<Object?, Object?> ||
+        createdAt is! String ||
+        idempotencyKey is! String ||
+        lineageId is! String ||
+        authPolicy is! String ||
+        state is! String) {
+      throw const InvalidMutationPayloadException(
+        'Invalid mutation operation payload',
+      );
+    }
+    validateJsonValue(json, 'operation');
+
+    final scope = json['authScope'];
+    final parsedAuthPolicy = _parseAuthPolicy(authPolicy);
+    final parsedScope = scope == null
+        ? null
+        : AuthScope.fromJson(_asObjectMap(scope));
+    if ((parsedAuthPolicy == AuthPolicy.required) != (parsedScope != null)) {
+      throw const InvalidMutationPayloadException(
+        'Auth policy and auth scope do not match',
+      );
+    }
+    final dependencies = _decodeList(
+      json['dependencies'],
+      'dependencies',
+      MutationDependency.fromJson,
+    );
+    final projections = _decodeList(
+      json['projections'],
+      'projections',
+      MutationProjectionDescriptor.fromJson,
+    );
+
+    return MutationOperation(
+      operationId: OperationId(operationId),
+      mutationKey: MutationKey.fromJson(_asObjectMap(mutationKey)),
+      variables: variables,
+      createdAt: DateTime.parse(createdAt),
+      idempotencyKey: IdempotencyKey(idempotencyKey),
+      lineageId: LineageId(lineageId),
+      authPolicy: parsedAuthPolicy,
+      state: parseMutationOperationState(state),
+      authScope: parsedScope,
+      dependencies: dependencies,
+      projections: projections,
+    );
+  }
+
+  /// Durable operation occurrence identity.
+  final OperationId operationId;
+
+  /// Logical operation registration key.
+  final MutationKey mutationKey;
+
+  /// JSON-safe encoded variables, not a runtime model or closure.
+  final Object? variables;
+
+  /// Enqueue timestamp.
+  final DateTime createdAt;
+
+  /// Stable key reused for automatic retries and restarts.
+  final IdempotencyKey idempotencyKey;
+
+  /// Lineage shared by the original operation and explicit repairs.
+  final LineageId lineageId;
+
+  /// Authentication requirement selected at enqueue.
+  final AuthPolicy authPolicy;
+
+  /// Exact captured scope for authenticated work.
+  final AuthScope? authScope;
+
+  /// Parent operation bindings.
+  final List<MutationDependency> dependencies;
+
+  /// Explicit cache projection plans.
+  final List<MutationProjectionDescriptor> projections;
+
+  /// Current durable lifecycle state.
+  final MutationOperationState state;
+
+  /// Serializes this operation into a JSON-safe map.
+  Map<String, Object?> toJson() => {
+    'operationId': operationId.value,
+    'mutationKey': mutationKey.toJson(),
+    'variables': variables,
+    'createdAt': createdAt.toIso8601String(),
+    'idempotencyKey': idempotencyKey.value,
+    'lineageId': lineageId.value,
+    'authPolicy': authPolicy.name,
+    'authScope': authScope?.toJson(),
+    'dependencies': dependencies.map((item) => item.toJson()).toList(),
+    'projections': projections.map((item) => item.toJson()).toList(),
+    'state': state.name,
+  };
+
+  static AuthPolicy _parseAuthPolicy(String value) {
+    for (final policy in AuthPolicy.values) {
+      if (policy.name == value) return policy;
+    }
+    throw InvalidMutationPayloadException('Unknown auth policy: $value');
+  }
+
+  static List<T> _decodeList<T>(
+    Object? value,
+    String fieldName,
+    T Function(Map<String, Object?> json) decode,
+  ) {
+    if (value == null) return <T>[];
+    if (value is! List<Object?>) {
+      throw InvalidMutationPayloadException('$fieldName must be a list');
+    }
+    return value
+        .map((item) {
+          if (item is! Map<Object?, Object?>) {
+            throw InvalidMutationPayloadException(
+              '$fieldName contains an invalid item',
+            );
+          }
+          return decode(_asObjectMap(item));
+        })
+        .toList(growable: false);
+  }
+
+  static Map<String, Object?> _asObjectMap(Object? value) {
+    if (value is! Map<Object?, Object?>) {
+      throw const InvalidMutationPayloadException('Expected a JSON object');
+    }
+    final result = <String, Object?>{};
+    for (final entry in value.entries) {
+      if (entry.key is! String) {
+        throw const InvalidMutationPayloadException(
+          'JSON object keys must be strings',
+        );
+      }
+      final key = entry.key;
+      if (key is! String) {
+        throw const InvalidMutationPayloadException(
+          'JSON object keys must be strings',
+        );
+      }
+      result[key] = entry.value;
+    }
+    return result;
+  }
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
@@ -150,7 +150,7 @@ class MutationOperation {
       operationId: OperationId(operationId),
       mutationKey: MutationKey.fromJson(_asObjectMap(mutationKey)),
       variables: variables,
-      createdAt: DateTime.parse(createdAt),
+      createdAt: _parseCreatedAt(createdAt),
       idempotencyKey: IdempotencyKey(idempotencyKey),
       lineageId: LineageId(lineageId),
       authPolicy: parsedAuthPolicy,
@@ -216,6 +216,16 @@ class MutationOperation {
     throw InvalidMutationPayloadException('Unknown auth policy: $value');
   }
 
+  static DateTime _parseCreatedAt(String value) {
+    try {
+      return DateTime.parse(value);
+    } on FormatException {
+      throw const InvalidMutationPayloadException(
+        'Invalid mutation operation timestamp',
+      );
+    }
+  }
+
   static List<T> _decodeList<T>(
     Object? value,
     String fieldName,
@@ -243,11 +253,6 @@ class MutationOperation {
     }
     final result = <String, Object?>{};
     for (final entry in value.entries) {
-      if (entry.key is! String) {
-        throw const InvalidMutationPayloadException(
-          'JSON object keys must be strings',
-        );
-      }
       final key = entry.key;
       if (key is! String) {
         throw const InvalidMutationPayloadException(

--- a/packages/fasq/lib/src/mutation/sync_engine/mutation_contracts.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/mutation_contracts.dart
@@ -1,0 +1,5 @@
+export 'codecs/mutation_codec.dart';
+export 'models/mutation_errors.dart';
+export 'models/mutation_identity.dart';
+export 'models/mutation_json.dart';
+export 'models/mutation_operation.dart';

--- a/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
@@ -114,6 +114,25 @@ void main() {
         throwsA(isA<InvalidMutationPayloadException>()),
       );
     });
+
+    test('rejects invalid operation timestamps as contract errors', () {
+      final operation = MutationOperation(
+        operationId: OperationId('operation-1'),
+        mutationKey: MutationKey(namespace: 'todos', name: 'create'),
+        variables: const <String, Object?>{},
+        createdAt: DateTime.utc(2026, 8, 19),
+        idempotencyKey: IdempotencyKey('idempotency-1'),
+        lineageId: LineageId('lineage-1'),
+        authPolicy: AuthPolicy.none,
+        state: MutationOperationState.pending,
+      );
+      final invalidPayload = operation.toJson()..['createdAt'] = 'not-a-date';
+
+      expect(
+        () => MutationOperation.fromJson(invalidPayload),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
+    });
   });
 
   group('MutationCodecRegistry', () {
@@ -176,6 +195,21 @@ void main() {
         ),
         throwsA(isA<UnknownMutationKeyException>()),
       );
+      expect(
+        () => registry.decode(
+          MutationKey(namespace: 'todos', name: 'create', version: 2),
+          'Todo',
+        ),
+        throwsA(isA<UnknownMutationKeyException>()),
+      );
+      expect(
+        () => MutationKey.fromJson(const <String, Object?>{
+          'namespace': 'todos',
+          'name': 'create',
+          'version': 1.5,
+        }),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
     });
 
     test('rejects duplicate registrations', () {
@@ -214,10 +248,20 @@ void main() {
         },
       ),
       authPolicy: AuthPolicy.required,
-      execute: (value) async => 'created:$value',
+      mutationFn: (value) async => 'created:$value',
     );
 
     expect(registry.authPolicyFor(key), AuthPolicy.required);
+    expect(
+      registry.readinessFor(key),
+      MutationRegistrationReadiness.ready,
+    );
+    expect(
+      registry.readinessFor(
+        MutationKey(namespace: 'todos', name: 'missing'),
+      ),
+      MutationRegistrationReadiness.missing,
+    );
     expect(await registry.execute(key, 'todo'), 'created:todo');
     expect(registry.registeredKeys, contains(key));
   });

--- a/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
@@ -1,0 +1,224 @@
+import 'package:fasq/fasq.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MutationKey', () {
+    test('keeps a stable versioned key and round trips', () {
+      final key = MutationKey(namespace: 'todos', name: 'create', version: 2);
+
+      final restored = MutationKey.fromJson(key.toJson());
+
+      expect(restored, equals(key));
+      expect(restored.key, equals('todos:create:v2'));
+    });
+
+    test('rejects invalid key segments and versions', () {
+      expect(
+        () => MutationKey(namespace: '', name: 'create'),
+        throwsArgumentError,
+      );
+      expect(
+        () => MutationKey(namespace: 'todos', name: 'create', version: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => MutationKey(namespace: 'todos:private', name: 'create'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('AuthScope and operation contracts', () {
+    test('round trips scope and operation descriptors', () {
+      final operation = MutationOperation(
+        operationId: OperationId('operation-1'),
+        mutationKey: MutationKey(namespace: 'todos', name: 'create'),
+        variables: const <String, Object?>{'title': 'Offline'},
+        createdAt: DateTime.utc(2026, 8, 19),
+        idempotencyKey: IdempotencyKey('idempotency-1'),
+        lineageId: LineageId('lineage-1'),
+        authPolicy: AuthPolicy.required,
+        authScope: AuthScope(
+          principalId: 'user-1',
+          tenantId: 'tenant-1',
+          authRealm: 'primary',
+        ),
+        dependencies: <MutationDependency>[
+          MutationDependency(
+            parentOperationId: OperationId('parent-1'),
+            parentResultPath: 'id',
+            childVariablePath: 'todoId',
+          ),
+        ],
+        projections: <MutationProjectionDescriptor>[
+          MutationProjectionDescriptor(
+            id: 'todo-detail',
+            queryKeys: const <String>['todo:temporary-1'],
+          ),
+        ],
+        state: MutationOperationState.pending,
+      );
+
+      final restored = MutationOperation.fromJson(operation.toJson());
+
+      expect(restored.operationId, equals(operation.operationId));
+      expect(restored.mutationKey, equals(operation.mutationKey));
+      expect(restored.variables, equals(operation.variables));
+      expect(restored.authScope, equals(operation.authScope));
+      expect(restored.dependencies.single.parentOperationId.value, 'parent-1');
+      expect(restored.projections.single.queryKeys, <String>[
+        'todo:temporary-1',
+      ]);
+      expect(restored.state, MutationOperationState.pending);
+    });
+
+    test('does not silently accept an unknown operation state', () {
+      expect(
+        () => parseMutationOperationState('futureState'),
+        throwsA(isA<UnknownMutationStateException>()),
+      );
+    });
+
+    test('requires exact scope for authenticated operations', () {
+      expect(
+        () => MutationOperation(
+          operationId: OperationId('operation-1'),
+          mutationKey: MutationKey(namespace: 'todos', name: 'create'),
+          variables: const <String, Object?>{},
+          createdAt: DateTime.utc(2026, 8, 19),
+          idempotencyKey: IdempotencyKey('idempotency-1'),
+          lineageId: LineageId('lineage-1'),
+          authPolicy: AuthPolicy.required,
+          state: MutationOperationState.pending,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects non-JSON operation variables', () {
+      final operation = MutationOperation(
+        operationId: OperationId('operation-1'),
+        mutationKey: MutationKey(namespace: 'todos', name: 'create'),
+        variables: const <String, Object?>{},
+        createdAt: DateTime.utc(2026, 8, 19),
+        idempotencyKey: IdempotencyKey('idempotency-1'),
+        lineageId: LineageId('lineage-1'),
+        authPolicy: AuthPolicy.none,
+        state: MutationOperationState.pending,
+      );
+      final invalidPayload = operation.toJson()
+        ..['variables'] = DateTime.utc(2026, 8, 19);
+
+      expect(
+        () => MutationOperation.fromJson(invalidPayload),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
+    });
+  });
+
+  group('MutationCodecRegistry', () {
+    final key = MutationKey(namespace: 'todos', name: 'create');
+
+    test('encodes and decodes typed variables', () {
+      final registry = MutationCodecRegistry()
+        ..register<Map<String, Object?>>(
+          key,
+          JsonMutationCodec<Map<String, Object?>>(
+            encoder: (value) => value,
+            decoder: (payload) {
+              if (payload is! Map<Object?, Object?>) {
+                throw const InvalidMutationPayloadException('Expected object');
+              }
+              return Map<String, Object?>.fromEntries(
+                payload.entries.map((entry) {
+                  if (entry.key is! String) {
+                    throw const InvalidMutationPayloadException(
+                      'Expected string keys',
+                    );
+                  }
+                  final entryKey = entry.key;
+                  if (entryKey is! String) {
+                    throw const InvalidMutationPayloadException(
+                      'Expected string keys',
+                    );
+                  }
+                  return MapEntry(entryKey, entry.value);
+                }),
+              );
+            },
+          ),
+        );
+
+      final payload = registry.encode(key, <String, Object?>{'title': 'Todo'});
+
+      expect(payload, <String, Object?>{'title': 'Todo'});
+      expect(registry.decode(key, payload), <String, Object?>{'title': 'Todo'});
+    });
+
+    test('rejects unsupported payloads and unknown keys', () {
+      final registry = MutationCodecRegistry()
+        ..register<Object?>(
+          key,
+          JsonMutationCodec<Object?>(
+            encoder: (value) => value,
+            decoder: (payload) => payload,
+          ),
+        );
+
+      expect(
+        () => registry.encode(key, DateTime.utc(2026)),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
+      expect(
+        () => registry.decode(
+          MutationKey(namespace: 'todos', name: 'missing'),
+          <String, Object?>{},
+        ),
+        throwsA(isA<UnknownMutationKeyException>()),
+      );
+    });
+
+    test('rejects duplicate registrations', () {
+      final registry = MutationCodecRegistry();
+      final codec = JsonMutationCodec<String>(
+        encoder: (value) => value,
+        decoder: (payload) {
+          if (payload is! String) {
+            throw const InvalidMutationPayloadException('Expected string');
+          }
+          return payload;
+        },
+      );
+
+      registry.register(key, codec);
+
+      expect(
+        () => registry.register(key, codec),
+        throwsA(isA<DuplicateMutationRegistrationException>()),
+      );
+    });
+  });
+
+  test('registers an executor without persisting the closure', () async {
+    final registry = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'todos', name: 'create');
+    registry.register<String, String>(
+      key: key,
+      codec: JsonMutationCodec<String>(
+        encoder: (value) => value,
+        decoder: (payload) {
+          if (payload is! String) {
+            throw const InvalidMutationPayloadException('Expected string');
+          }
+          return payload;
+        },
+      ),
+      authPolicy: AuthPolicy.required,
+      execute: (value) async => 'created:$value',
+    );
+
+    expect(registry.authPolicyFor(key), AuthPolicy.required);
+    expect(await registry.execute(key, 'todo'), 'created:todo');
+    expect(registry.registeredKeys, contains(key));
+  });
+}


### PR DESCRIPTION
## Summary

Adds the transport-agnostic durable contract boundary required by offline mutation storage and replay.

## Changes

- Add restart-stable versioned `MutationKey`, operation/idempotency/lineage IDs, exact `AuthScope`, lifecycle states, normalized failure categories, dependency descriptors, and projection descriptors.
- Add recursive JSON validation and typed codec registration with duplicate, unknown-key, and invalid-payload errors.
- Bind runtime registration to the existing mutation function; closures and credentials remain runtime-only and are never serialized.
- Expose explicit registration readiness metadata.
- Enforce `AuthPolicy.required` with an exact `AuthScope`.
- Export the contract surface from `fasq.dart`.

## Verification

- `flutter test packages/fasq/test/mutation` — 43 tests passed.
- Focused `dart analyze` — no issues.
- No HTTP or Dio dependency in the new sync-engine boundary.

## Out of scope

Durable storage, replay scheduling, projection execution, UI, and public `Mutation` integration remain separate follow-up changes.

---

**Part 2 of 3** in this stack:

[offline-sync-engine](https://github.com/ishafiul/fasq/pull/61) #61 <br>
&nbsp;&nbsp;&nbsp;&nbsp;↳ **[task-10-durable-sync-contracts](https://github.com/ishafiul/fasq/pull/62)** #62 ← this <br>
&nbsp;&nbsp;&nbsp;&nbsp;↳ [task-11-durable-outbox](https://github.com/ishafiul/fasq/pull/63) #63 <br>

