### PR TITLE
feat: Add crash-safe dependency-aware replay coordinator

### DIFF
--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -32,6 +32,7 @@ export 'src/mutation/network_status.dart';
 export 'src/mutation/offline_queue.dart';
 export 'src/mutation/sync_engine/kahn_dag.dart';
 export 'src/mutation/sync_engine/mutation_contracts.dart';
+export 'src/mutation/sync_engine/replay/replay_coordinator.dart';
 export 'src/mutation/sync_engine/store/durable_outbox.dart';
 export 'src/mutation/sync_engine/store/file_durable_outbox.dart';
 export 'src/mutation/sync_engine/store/outbox_envelope.dart';

--- a/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/codecs/mutation_codec.dart
@@ -94,6 +94,7 @@ class MutationRegistrationRegistry {
     required MutationCodec<TVariables> codec,
     required Future<TData> Function(TVariables variables) mutationFn,
     AuthPolicy authPolicy = AuthPolicy.none,
+    Object? Function(TData data)? resultEncoder,
   }) {
     if (_registrations.containsKey(key)) {
       throw DuplicateMutationRegistrationException(key.key);
@@ -103,6 +104,7 @@ class MutationRegistrationRegistry {
       codec: codec,
       mutationFn: mutationFn,
       authPolicy: authPolicy,
+      resultEncoder: resultEncoder,
     );
   }
 
@@ -172,12 +174,14 @@ class _RegisteredMutation<TData, TVariables> {
     required this.codec,
     required this.mutationFn,
     required this.authPolicy,
+    required this.resultEncoder,
   });
 
   final MutationKey key;
   final MutationCodec<TVariables> codec;
   final Future<TData> Function(TVariables variables) mutationFn;
   final AuthPolicy authPolicy;
+  final Object? Function(TData data)? resultEncoder;
 
   Object? encode(Object? variables) {
     if (variables is! TVariables) {
@@ -198,7 +202,15 @@ class _RegisteredMutation<TData, TVariables> {
         'expected $TVariables',
       );
     }
-    return mutationFn(variables);
+    final result = await mutationFn(variables);
+    try {
+      final encoder = resultEncoder;
+      final encoded = encoder == null ? result : encoder(result);
+      validateJsonValue(encoded, 'mutation result');
+      return encoded;
+    } on Object {
+      throw const InvalidMutationResultException();
+    }
   }
 }
 

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_errors.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_errors.dart
@@ -78,6 +78,13 @@ class InvalidMutationPayloadException extends MutationContractException {
   const InvalidMutationPayloadException(super.message);
 }
 
+/// Raised when an executor result cannot be durably encoded.
+class InvalidMutationResultException extends MutationContractException {
+  /// Creates an invalid-result exception.
+  const InvalidMutationResultException()
+    : super('Mutation result could not be encoded safely');
+}
+
 /// Raised when a persisted key has no registered codec or executor.
 class UnknownMutationKeyException extends MutationContractException {
   /// Creates an unknown-key exception.

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
@@ -60,6 +60,7 @@ class MutationOperation {
     required LineageId lineageId,
     required AuthPolicy authPolicy,
     required MutationOperationState state,
+    int priority = 0,
     AuthScope? authScope,
     List<MutationDependency> dependencies = const <MutationDependency>[],
     List<MutationProjectionDescriptor> projections =
@@ -82,6 +83,7 @@ class MutationOperation {
       lineageId: lineageId,
       authPolicy: authPolicy,
       state: state,
+      priority: priority,
       authScope: authScope,
       dependencies: List.unmodifiable(dependencies),
       projections: List.unmodifiable(projections),
@@ -97,6 +99,7 @@ class MutationOperation {
     required this.lineageId,
     required this.authPolicy,
     required this.state,
+    required this.priority,
     required this.dependencies,
     required this.projections,
     this.authScope,
@@ -112,13 +115,15 @@ class MutationOperation {
     final lineageId = json['lineageId'];
     final authPolicy = json['authPolicy'];
     final state = json['state'];
+    final priority = json['priority'];
     if (operationId is! String ||
         mutationKey is! Map<Object?, Object?> ||
         createdAt is! String ||
         idempotencyKey is! String ||
         lineageId is! String ||
         authPolicy is! String ||
-        state is! String) {
+        state is! String ||
+        (priority != null && priority is! int)) {
       throw const InvalidMutationPayloadException(
         'Invalid mutation operation payload',
       );
@@ -155,6 +160,7 @@ class MutationOperation {
       lineageId: LineageId(lineageId),
       authPolicy: parsedAuthPolicy,
       state: parseMutationOperationState(state),
+      priority: priority as int? ?? 0,
       authScope: parsedScope,
       dependencies: dependencies,
       projections: projections,
@@ -194,6 +200,31 @@ class MutationOperation {
   /// Current durable lifecycle state.
   final MutationOperationState state;
 
+  /// Deterministic scheduling priority. Higher values run first.
+  final int priority;
+
+  /// Returns this operation with selected durable fields replaced.
+  MutationOperation copyWith({
+    Object? variables = _unset,
+    MutationOperationState? state,
+    int? priority,
+  }) {
+    return MutationOperation(
+      operationId: operationId,
+      mutationKey: mutationKey,
+      variables: identical(variables, _unset) ? this.variables : variables,
+      createdAt: createdAt,
+      idempotencyKey: idempotencyKey,
+      lineageId: lineageId,
+      authPolicy: authPolicy,
+      state: state ?? this.state,
+      priority: priority ?? this.priority,
+      authScope: authScope,
+      dependencies: dependencies,
+      projections: projections,
+    );
+  }
+
   /// Serializes this operation into a JSON-safe map.
   Map<String, Object?> toJson() => {
     'operationId': operationId.value,
@@ -207,6 +238,7 @@ class MutationOperation {
     'dependencies': dependencies.map((item) => item.toJson()).toList(),
     'projections': projections.map((item) => item.toJson()).toList(),
     'state': state.name,
+    'priority': priority,
   };
 
   static AuthPolicy _parseAuthPolicy(String value) {
@@ -263,4 +295,10 @@ class MutationOperation {
     }
     return result;
   }
+}
+
+const _unset = _Unset();
+
+class _Unset {
+  const _Unset();
 }

--- a/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
@@ -1,0 +1,997 @@
+import 'dart:async';
+
+import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/kahn_dag.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
+import 'package:fasq/src/mutation/sync_engine/store/durable_outbox.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_models.dart';
+
+/// Why a pending operation cannot be admitted to replay.
+enum ReplayBlockReason {
+  /// A required parent operation is absent from active work and history.
+  missingDependency,
+
+  /// The operation belongs to a dependency cycle.
+  cycle,
+
+  /// The operation depends on itself.
+  selfDependency,
+
+  /// A prerequisite completed terminally without succeeding.
+  parentFailure,
+
+  /// The operation has no runtime codec and executor registration.
+  missingRegistration,
+
+  /// A parent-result binding is structurally invalid.
+  invalidBinding,
+
+  /// A required parent result field is absent or not JSON-safe.
+  missingParentResult,
+
+  /// An active operation reuses an ID from active or terminal storage.
+  duplicateOperation,
+}
+
+/// Safe, durable diagnostic for a blocked replay operation.
+class ReplayDiagnostic {
+  /// Creates a replay diagnostic.
+  ReplayDiagnostic({
+    required this.operationId,
+    required this.reason,
+    required this.messageKey,
+    List<OperationId> relatedOperationIds = const <OperationId>[],
+    List<String> missingDependencyIds = const <String>[],
+  }) : relatedOperationIds = List.unmodifiable(relatedOperationIds),
+       missingDependencyIds = List.unmodifiable(missingDependencyIds);
+
+  /// Operation that remains blocked.
+  final OperationId operationId;
+
+  /// Stable reason category.
+  final ReplayBlockReason reason;
+
+  /// Safe message key for application presentation.
+  final String messageKey;
+
+  /// Parent operations relevant to the diagnostic.
+  final List<OperationId> relatedOperationIds;
+
+  /// Missing operation IDs, when [reason] is
+  /// [ReplayBlockReason.missingDependency].
+  final List<String> missingDependencyIds;
+
+  /// Serializes the diagnostic for the outbox metadata ledger.
+  Map<String, Object?> toJson() => {
+    'operationId': operationId.value,
+    'reason': reason.name,
+    'messageKey': messageKey,
+    'relatedOperationIds': relatedOperationIds
+        .map((operationId) => operationId.value)
+        .toList(growable: false),
+    'missingDependencyIds': missingDependencyIds,
+  };
+}
+
+/// Observable result of one replay request.
+class ReplayRunResult {
+  /// Creates a replay result.
+  ReplayRunResult({
+    required List<OperationId> executedOperationIds,
+    required List<OperationId> failedOperationIds,
+    required List<OperationId> recoveredUnknownOutcomeIds,
+    required List<ReplayDiagnostic> blockedOperations,
+  }) : executedOperationIds = List.unmodifiable(executedOperationIds),
+       failedOperationIds = List.unmodifiable(failedOperationIds),
+       recoveredUnknownOutcomeIds = List.unmodifiable(
+         recoveredUnknownOutcomeIds,
+       ),
+       blockedOperations = List.unmodifiable(blockedOperations);
+
+  /// Operations whose registered executor was invoked.
+  final List<OperationId> executedOperationIds;
+
+  /// Operations whose executor returned a failure recorded for repair.
+  final List<OperationId> failedOperationIds;
+
+  /// Operations recovered from a prior process crash.
+  final List<OperationId> recoveredUnknownOutcomeIds;
+
+  /// Operations left blocked with durable diagnostics.
+  final List<ReplayDiagnostic> blockedOperations;
+
+  /// Whether this request invoked at least one executor.
+  bool get didExecute => executedOperationIds.isNotEmpty;
+}
+
+/// Coordinates one-owner, dependency-aware replay over a durable outbox.
+///
+/// The coordinator owns scheduling and durable state transitions. The
+/// registration registry remains the only runtime executor seam, so immediate
+/// execution and replay cannot drift into separate mutation implementations.
+class DurableReplayCoordinator {
+  /// Creates a replay coordinator.
+  DurableReplayCoordinator({
+    required DurableOutboxStore store,
+    required MutationRegistrationRegistry registrations,
+    DateTime Function()? now,
+  }) : _store = store,
+       _registrations = registrations,
+       _now = now ?? DateTime.now;
+
+  static const _diagnosticsMetadataKey = 'replayDiagnostics';
+
+  final DurableOutboxStore _store;
+  final MutationRegistrationRegistry _registrations;
+  final DateTime Function() _now;
+  Future<void> _tail = Future<void>.value();
+  bool _isOpen = false;
+  List<OperationId> _recoveredUnknownOutcomeIds = const <OperationId>[];
+
+  /// Opens the store and converts leftover running work into safe dead letters.
+  Future<void> open() {
+    return _serialized(() async {
+      if (_isOpen) return;
+      await _store.open();
+      try {
+        _recoveredUnknownOutcomeIds = await _recoverInterrupted();
+        _isOpen = true;
+      } on Object {
+        try {
+          await _store.close();
+        } on Object {
+          // Preserve the recovery failure; the store owns its cleanup error.
+        }
+        rethrow;
+      }
+    });
+  }
+
+  /// Replays all currently admissible work in deterministic order.
+  Future<ReplayRunResult> replay() {
+    return _serialized(() async {
+      _requireOpen();
+      final executed = <OperationId>[];
+      final failed = <OperationId>[];
+      final blocked = <String, ReplayDiagnostic>{};
+      final recovered = List<OperationId>.from(_recoveredUnknownOutcomeIds);
+      _recoveredUnknownOutcomeIds = const <OperationId>[];
+
+      await _clearDiagnostics();
+      while (true) {
+        final selection = _select(_store.snapshot);
+        for (final diagnostic in selection.diagnostics) {
+          _recordDiagnostic(blocked, diagnostic);
+        }
+        if (selection.diagnostics.isNotEmpty) {
+          await _persistDiagnostics(selection);
+        }
+
+        final next = selection.orderedNodes.isEmpty
+            ? null
+            : selection.orderedNodes.first.payload;
+        if (next == null) break;
+
+        final started = await _start(next);
+        if (started == null) continue;
+        final operation = started.operation;
+        executed.add(operation.operationId);
+
+        Object? result;
+        try {
+          result = await _registrations.execute(
+            operation.mutationKey,
+            operation.variables,
+          );
+        } on Object catch (error) {
+          failed.add(operation.operationId);
+          await _completeFailure(
+            started,
+            error,
+            unknownOutcome: !_isDeterministicFailure(error),
+          );
+          continue;
+        }
+        await _completeSuccess(started, result);
+      }
+
+      return ReplayRunResult(
+        executedOperationIds: List.unmodifiable(executed),
+        failedOperationIds: List.unmodifiable(failed),
+        recoveredUnknownOutcomeIds: List.unmodifiable(recovered),
+        blockedOperations: List.unmodifiable(blocked.values),
+      );
+    });
+  }
+
+  /// Closes the coordinator and releases the outbox owner marker.
+  Future<void> close() {
+    return _serialized(() async {
+      if (!_isOpen) return;
+      await _store.close();
+      _isOpen = false;
+    });
+  }
+
+  Future<List<OperationId>> _recoverInterrupted() async {
+    final running = _store.snapshot.active
+        .where((operation) => operation.state == MutationOperationState.running)
+        .toList(growable: false);
+    if (running.isEmpty) return const <OperationId>[];
+
+    final expectedGeneration = _store.generation;
+    await _store.transact(
+      (current) {
+        final runningIds = running
+            .map((operation) => operation.operationId)
+            .toSet();
+        final active = current.active
+            .where((operation) => !runningIds.contains(operation.operationId))
+            .toList();
+        final deadLetters = [...current.deadLetters];
+        final history = [...current.history];
+        for (final operation in running) {
+          final unknownOutcome = operation.copyWith(
+            state: MutationOperationState.unknownOutcome,
+          );
+          deadLetters.add(
+            OutboxDeadLetter(
+              operation: unknownOutcome,
+              category: MutationFailureCategory.unknown,
+              messageKey: 'sync.replay.unknown_outcome',
+              retryable: false,
+              repairable: true,
+              failedAt: _now(),
+            ),
+          );
+          history.add(
+            OutboxHistoryEntry.validated(
+              operationId: operation.operationId,
+              state: MutationOperationState.unknownOutcome,
+              completedAt: _now(),
+            ),
+          );
+        }
+        return current.copyWith(
+          active: active,
+          deadLetters: deadLetters,
+          history: history,
+        );
+      },
+      expectedGeneration: expectedGeneration,
+    );
+    return running
+        .map((operation) => operation.operationId)
+        .toList(growable: false);
+  }
+
+  _ReplaySelection _select(OutboxSnapshot snapshot) {
+    final pending = snapshot.active
+        .where((operation) => operation.state == MutationOperationState.pending)
+        .toList(growable: false);
+    if (pending.isEmpty) {
+      return const _ReplaySelection(
+        generation: 0,
+        orderedNodes: <SyncDagNode<MutationOperation>>[],
+        diagnostics: <ReplayDiagnostic>[],
+      );
+    }
+
+    final pendingIds = pending
+        .map((operation) => operation.operationId.value)
+        .toSet();
+    final directDiagnostics = <String, ReplayDiagnostic>{};
+    final deferredIds = <String>{};
+
+    // A history/dead-letter pair is the intentional terminal record for one
+    // operation. Only a pending active record conflicts with those ledgers.
+    final terminalOperationIds = <String>{
+      ...snapshot.history.map((entry) => entry.operationId.value),
+      ...snapshot.deadLetters.map(
+        (entry) => entry.operation.operationId.value,
+      ),
+    };
+    final seenOperationIds = <String>{};
+    for (final operation in pending) {
+      if (!seenOperationIds.add(operation.operationId.value) ||
+          terminalOperationIds.contains(operation.operationId.value)) {
+        _recordDiagnostic(
+          directDiagnostics,
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.duplicateOperation,
+            'sync.replay.duplicate_operation',
+          ),
+        );
+      }
+    }
+
+    for (final operation in pending) {
+      if (!_registrations.contains(operation.mutationKey)) {
+        _recordDiagnostic(
+          directDiagnostics,
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.missingRegistration,
+            'sync.replay.missing_registration',
+          ),
+        );
+      }
+      final childBindingPaths = <String>{};
+      for (final dependency in operation.dependencies) {
+        final parentId = dependency.parentOperationId.value;
+        if (parentId == operation.operationId.value) {
+          _recordDiagnostic(
+            directDiagnostics,
+            _diagnostic(
+              operation.operationId,
+              ReplayBlockReason.selfDependency,
+              'sync.replay.self_dependency',
+              related: [dependency.parentOperationId],
+            ),
+          );
+          continue;
+        }
+        final childVariablePath = dependency.childVariablePath;
+        if (!_hasValidBinding(dependency) ||
+            (childVariablePath != null &&
+                !childBindingPaths.add(childVariablePath))) {
+          _recordDiagnostic(
+            directDiagnostics,
+            _diagnostic(
+              operation.operationId,
+              ReplayBlockReason.invalidBinding,
+              'sync.replay.invalid_parent_binding',
+              related: [dependency.parentOperationId],
+            ),
+          );
+          continue;
+        }
+
+        final activeParent = _findActive(snapshot, parentId);
+        final historyParent = _findHistory(snapshot, parentId);
+        final deadLetterParent = _findDeadLetter(snapshot, parentId);
+        if (activeParent != null && terminalOperationIds.contains(parentId)) {
+          _recordDiagnostic(
+            directDiagnostics,
+            _diagnostic(
+              operation.operationId,
+              ReplayBlockReason.duplicateOperation,
+              'sync.replay.duplicate_operation',
+              related: [dependency.parentOperationId],
+            ),
+          );
+          continue;
+        }
+        if (historyParent?.state == MutationOperationState.succeeded) continue;
+        if (deadLetterParent != null ||
+            activeParent?.state == MutationOperationState.failedTerminal ||
+            activeParent?.state == MutationOperationState.unknownOutcome ||
+            activeParent?.state == MutationOperationState.blocked ||
+            (historyParent != null &&
+                historyParent.state != MutationOperationState.succeeded)) {
+          _recordDiagnostic(
+            directDiagnostics,
+            _diagnostic(
+              operation.operationId,
+              ReplayBlockReason.parentFailure,
+              'sync.replay.parent_failed',
+              related: [dependency.parentOperationId],
+            ),
+          );
+          continue;
+        }
+        if (activeParent == null && historyParent == null) {
+          _recordDiagnostic(
+            directDiagnostics,
+            _diagnostic(
+              operation.operationId,
+              ReplayBlockReason.missingDependency,
+              'sync.replay.missing_dependency',
+              missing: [parentId],
+            ),
+          );
+          continue;
+        }
+        if (activeParent != null && !pendingIds.contains(parentId)) {
+          deferredIds.add(operation.operationId.value);
+        }
+      }
+    }
+
+    final candidates = pending
+        .where(
+          (operation) =>
+              !directDiagnostics.containsKey(operation.operationId.value) &&
+              !deferredIds.contains(operation.operationId.value),
+        )
+        .map(
+          (operation) => SyncDagNode<MutationOperation>(
+            id: operation.operationId.value,
+            payload: operation,
+            dependsOnIds: operation.dependencies
+                .map((dependency) => dependency.parentOperationId.value)
+                .where(pendingIds.contains)
+                .toList(growable: false),
+          ),
+        )
+        .toList(growable: false);
+
+    final resolution = const KahnDagSorter<MutationOperation>(
+      readyNodeComparator: _compareReadyNodes,
+    ).resolve(candidates);
+    final diagnostics = <ReplayDiagnostic>[...directDiagnostics.values];
+    for (final blockedNode in resolution.blockedNodes) {
+      final reason = blockedNode.reason;
+      final missingIds = blockedNode.missingDependencyIds;
+      final parentFailure = missingIds.any(directDiagnostics.containsKey);
+      diagnostics.add(
+        _diagnostic(
+          blockedNode.node.payload.operationId,
+          parentFailure
+              ? ReplayBlockReason.parentFailure
+              : switch (reason) {
+                  SyncDagBlockReason.missingDependency =>
+                    ReplayBlockReason.missingDependency,
+                  SyncDagBlockReason.cycle => ReplayBlockReason.cycle,
+                  SyncDagBlockReason.selfDependency =>
+                    ReplayBlockReason.selfDependency,
+                },
+          parentFailure ? 'sync.replay.parent_failed' : _messageKeyFor(reason),
+          missing: parentFailure ? const <String>[] : missingIds,
+        ),
+      );
+    }
+    return _ReplaySelection(
+      generation: _store.generation,
+      orderedNodes: resolution.orderedNodes,
+      diagnostics: _deduplicateDiagnostics(diagnostics),
+    );
+  }
+
+  Future<_StartedOperation?> _start(MutationOperation operation) async {
+    final expectedGeneration = _store.generation;
+    final snapshot = _store.snapshot;
+    final current = _findActive(snapshot, operation.operationId.value);
+    if (current == null || current.state != MutationOperationState.pending) {
+      return null;
+    }
+    final projection = _resolveDependencies(current, snapshot);
+    final projectionDiagnostic = projection.diagnostic;
+    if (projectionDiagnostic != null) {
+      await _persistDiagnostics(
+        _ReplaySelection(
+          generation: _store.generation,
+          orderedNodes: const <SyncDagNode<MutationOperation>>[],
+          diagnostics: <ReplayDiagnostic>[projectionDiagnostic],
+        ),
+      );
+      return null;
+    }
+    final started = current.copyWith(
+      variables: projection.variables,
+      state: MutationOperationState.running,
+    );
+    final committed = await _store.transact(
+      (latest) {
+        final latestOperation = _findActive(
+          latest,
+          operation.operationId.value,
+        );
+        if (latestOperation == null ||
+            latestOperation.state != MutationOperationState.pending) {
+          return latest;
+        }
+        return latest.copyWith(
+          active: _replaceActive(latest.active, started),
+        );
+      },
+      expectedGeneration: expectedGeneration,
+    );
+    final result = _findActive(committed, operation.operationId.value);
+    if (result == null || result.state != MutationOperationState.running) {
+      return null;
+    }
+    return _StartedOperation(
+      operation: result,
+      generation: _store.generation,
+    );
+  }
+
+  Future<void> _completeSuccess(
+    _StartedOperation started,
+    Object? result,
+  ) async {
+    final operation = started.operation;
+    OutboxHistoryEntry history;
+    try {
+      history = OutboxHistoryEntry.validated(
+        operationId: operation.operationId,
+        state: MutationOperationState.succeeded,
+        completedAt: _now(),
+        resultProjection: result,
+      );
+    } on Object {
+      await _completeFailure(
+        started,
+        const InvalidMutationPayloadException(
+          'Mutation result cannot be persisted safely',
+        ),
+        unknownOutcome: true,
+      );
+      return;
+    }
+    await _store.transact(
+      (current) {
+        final active = _findActive(current, operation.operationId.value);
+        if (active == null || active.state != MutationOperationState.running) {
+          throw StateError(
+            'Replay completion lost operation ${operation.operationId.value}',
+          );
+        }
+        return current.copyWith(
+          active: _removeActive(current.active, operation.operationId),
+          history: [...current.history, history],
+        );
+      },
+      expectedGeneration: started.generation,
+    );
+  }
+
+  Future<void> _completeFailure(
+    _StartedOperation started,
+    Object error, {
+    bool unknownOutcome = false,
+  }) async {
+    final operation = started.operation;
+    final category = unknownOutcome
+        ? MutationFailureCategory.unknown
+        : _failureCategory(error);
+    final state = unknownOutcome
+        ? MutationOperationState.unknownOutcome
+        : MutationOperationState.failedTerminal;
+    await _store.transact(
+      (current) {
+        final active = _findActive(current, operation.operationId.value);
+        if (active == null || active.state != MutationOperationState.running) {
+          throw StateError(
+            'Replay failure lost operation ${operation.operationId.value}',
+          );
+        }
+        final failedOperation = operation.copyWith(state: state);
+        return current.copyWith(
+          active: _removeActive(current.active, operation.operationId),
+          deadLetters: [
+            ...current.deadLetters,
+            OutboxDeadLetter(
+              operation: failedOperation,
+              category: category,
+              messageKey: unknownOutcome
+                  ? 'sync.replay.unknown_outcome'
+                  : _messageKeyForFailure(category),
+              retryable: false,
+              repairable: true,
+              failedAt: _now(),
+            ),
+          ],
+          history: [
+            ...current.history,
+            OutboxHistoryEntry.validated(
+              operationId: operation.operationId,
+              state: state,
+              completedAt: _now(),
+            ),
+          ],
+        );
+      },
+      expectedGeneration: started.generation,
+    );
+  }
+
+  Future<void> _clearDiagnostics() async {
+    final snapshot = _store.snapshot;
+    if (!snapshot.metadata.containsKey(_diagnosticsMetadataKey)) return;
+    final metadata = Map<String, Object?>.from(snapshot.metadata)
+      ..remove(_diagnosticsMetadataKey);
+    await _store.transact(
+      (current) => current.copyWith(metadata: metadata),
+      expectedGeneration: _store.generation,
+    );
+  }
+
+  Future<void> _persistDiagnostics(_ReplaySelection selection) async {
+    if (selection.diagnostics.isEmpty) return;
+    await _store.transact(
+      (current) {
+        final diagnosticById = <String, ReplayDiagnostic>{
+          for (final diagnostic in selection.diagnostics)
+            diagnostic.operationId.value: diagnostic,
+        };
+        final active = current.active
+            .map((operation) {
+              final diagnostic = diagnosticById[operation.operationId.value];
+              if (diagnostic == null ||
+                  operation.state != MutationOperationState.pending) {
+                return operation;
+              }
+              return operation.copyWith(state: MutationOperationState.blocked);
+            })
+            .toList(growable: false);
+        final metadata = Map<String, Object?>.from(current.metadata)
+          ..[_diagnosticsMetadataKey] = selection.diagnostics
+              .map((diagnostic) => diagnostic.toJson())
+              .toList(growable: false);
+        return current.copyWith(active: active, metadata: metadata);
+      },
+      expectedGeneration: selection.generation,
+    );
+  }
+
+  _ProjectionResult _resolveDependencies(
+    MutationOperation operation,
+    OutboxSnapshot snapshot,
+  ) {
+    var variables = operation.variables;
+    for (final dependency in operation.dependencies) {
+      if (dependency.parentResultPath == null &&
+          dependency.childVariablePath == null) {
+        continue;
+      }
+      final parent = _findHistory(
+        snapshot,
+        dependency.parentOperationId.value,
+      );
+      if (parent == null || parent.state != MutationOperationState.succeeded) {
+        return _ProjectionResult.diagnostic(
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.missingParentResult,
+            'sync.replay.parent_result_missing',
+            related: [dependency.parentOperationId],
+          ),
+        );
+      }
+      final parentResultPath = dependency.parentResultPath;
+      final childVariablePath = dependency.childVariablePath;
+      if (parentResultPath == null || childVariablePath == null) {
+        return _ProjectionResult.diagnostic(
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.invalidBinding,
+            'sync.replay.invalid_parent_binding',
+            related: [dependency.parentOperationId],
+          ),
+        );
+      }
+      final lookup = _readJsonPath(parent.resultProjection, parentResultPath);
+      if (!lookup.found) {
+        return _ProjectionResult.diagnostic(
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.missingParentResult,
+            'sync.replay.parent_result_missing',
+            related: [dependency.parentOperationId],
+          ),
+        );
+      }
+      try {
+        variables = _writeJsonPath(
+          variables,
+          childVariablePath,
+          lookup.value,
+        );
+      } on InvalidMutationPayloadException {
+        return _ProjectionResult.diagnostic(
+          _diagnostic(
+            operation.operationId,
+            ReplayBlockReason.invalidBinding,
+            'sync.replay.invalid_parent_binding',
+            related: [dependency.parentOperationId],
+          ),
+        );
+      }
+    }
+    return _ProjectionResult.variables(variables);
+  }
+
+  bool _hasValidBinding(MutationDependency dependency) {
+    final parentResultPath = dependency.parentResultPath;
+    final childVariablePath = dependency.childVariablePath;
+    if ((parentResultPath == null) != (childVariablePath == null)) {
+      return false;
+    }
+    return (parentResultPath == null || _isValidJsonPath(parentResultPath)) &&
+        (childVariablePath == null || _isValidJsonPath(childVariablePath));
+  }
+
+  void _requireOpen() {
+    if (!_isOpen) {
+      throw StateError('The replay coordinator is not open');
+    }
+  }
+
+  Future<T> _serialized<T>(Future<T> Function() operation) async {
+    final previous = _tail;
+    final completer = _Completion();
+    _tail = completer.future;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      completer.complete();
+    }
+  }
+}
+
+class _ReplaySelection {
+  const _ReplaySelection({
+    required this.generation,
+    required this.orderedNodes,
+    required this.diagnostics,
+  });
+
+  final int generation;
+  final List<SyncDagNode<MutationOperation>> orderedNodes;
+  final List<ReplayDiagnostic> diagnostics;
+}
+
+class _StartedOperation {
+  const _StartedOperation({required this.operation, required this.generation});
+
+  final MutationOperation operation;
+  final int generation;
+}
+
+class _ProjectionResult {
+  const _ProjectionResult._({this.variables, this.diagnostic});
+
+  factory _ProjectionResult.variables(Object? variables) =>
+      _ProjectionResult._(variables: variables);
+
+  factory _ProjectionResult.diagnostic(ReplayDiagnostic diagnostic) =>
+      _ProjectionResult._(diagnostic: diagnostic);
+
+  final Object? variables;
+  final ReplayDiagnostic? diagnostic;
+}
+
+class _PathLookup {
+  const _PathLookup({required this.found, required this.value});
+
+  final bool found;
+  final Object? value;
+}
+
+class _Completion {
+  final _completer = Completer<void>();
+
+  Future<void> get future => _completer.future;
+
+  void complete() => _completer.complete();
+}
+
+ReplayDiagnostic _diagnostic(
+  OperationId operationId,
+  ReplayBlockReason reason,
+  String messageKey, {
+  List<OperationId> related = const <OperationId>[],
+  List<String> missing = const <String>[],
+}) {
+  return ReplayDiagnostic(
+    operationId: operationId,
+    reason: reason,
+    messageKey: messageKey,
+    relatedOperationIds: List.unmodifiable(related),
+    missingDependencyIds: List.unmodifiable(missing),
+  );
+}
+
+void _recordDiagnostic(
+  Map<String, ReplayDiagnostic> diagnostics,
+  ReplayDiagnostic diagnostic,
+) {
+  final operationId = diagnostic.operationId.value;
+  final previous = diagnostics[operationId];
+  diagnostics[operationId] = previous == null
+      ? diagnostic
+      : _mergeDiagnosticDetails(previous, diagnostic);
+}
+
+ReplayDiagnostic _mergeDiagnosticDetails(
+  ReplayDiagnostic previous,
+  ReplayDiagnostic current,
+) {
+  return ReplayDiagnostic(
+    operationId: current.operationId,
+    reason: current.reason,
+    messageKey: current.messageKey,
+    relatedOperationIds: _appendUnique(
+      previous.relatedOperationIds,
+      current.relatedOperationIds,
+    ),
+    missingDependencyIds: _appendUnique(
+      previous.missingDependencyIds,
+      current.missingDependencyIds,
+    ),
+  );
+}
+
+List<T> _appendUnique<T>(Iterable<T> previous, Iterable<T> current) {
+  final values = <T>{...previous}..addAll(current);
+  return List.unmodifiable(values);
+}
+
+List<ReplayDiagnostic> _deduplicateDiagnostics(
+  Iterable<ReplayDiagnostic> diagnostics,
+) {
+  final byId = <String, ReplayDiagnostic>{};
+  for (final diagnostic in diagnostics) {
+    _recordDiagnostic(byId, diagnostic);
+  }
+  return byId.values.toList(growable: false);
+}
+
+int _compareReadyNodes(
+  SyncDagNode<MutationOperation> left,
+  SyncDagNode<MutationOperation> right,
+) {
+  final priority = right.payload.priority.compareTo(left.payload.priority);
+  if (priority != 0) return priority;
+  final createdAt = left.payload.createdAt.compareTo(right.payload.createdAt);
+  if (createdAt != 0) return createdAt;
+  return left.payload.operationId.value.compareTo(
+    right.payload.operationId.value,
+  );
+}
+
+String _messageKeyFor(SyncDagBlockReason reason) {
+  return switch (reason) {
+    SyncDagBlockReason.missingDependency => 'sync.replay.missing_dependency',
+    SyncDagBlockReason.cycle => 'sync.replay.cycle',
+    SyncDagBlockReason.selfDependency => 'sync.replay.self_dependency',
+  };
+}
+
+MutationFailureCategory _failureCategory(Object error) {
+  if (error is InvalidMutationPayloadException) {
+    return MutationFailureCategory.payload;
+  }
+  if (error is UnknownMutationKeyException) {
+    return MutationFailureCategory.executor;
+  }
+  return MutationFailureCategory.unknown;
+}
+
+bool _isDeterministicFailure(Object error) {
+  return error is InvalidMutationPayloadException ||
+      error is UnknownMutationKeyException;
+}
+
+String _messageKeyForFailure(MutationFailureCategory category) {
+  return 'sync.replay.failure.${category.name}';
+}
+
+MutationOperation? _findActive(OutboxSnapshot snapshot, String operationId) {
+  for (final operation in snapshot.active) {
+    if (operation.operationId.value == operationId) return operation;
+  }
+  return null;
+}
+
+OutboxHistoryEntry? _findHistory(OutboxSnapshot snapshot, String operationId) {
+  for (final entry in snapshot.history) {
+    if (entry.operationId.value == operationId) return entry;
+  }
+  return null;
+}
+
+OutboxDeadLetter? _findDeadLetter(OutboxSnapshot snapshot, String operationId) {
+  for (final entry in snapshot.deadLetters) {
+    if (entry.operation.operationId.value == operationId) return entry;
+  }
+  return null;
+}
+
+List<MutationOperation> _replaceActive(
+  List<MutationOperation> active,
+  MutationOperation replacement,
+) {
+  return [
+    for (final operation in active)
+      if (operation.operationId == replacement.operationId)
+        replacement
+      else
+        operation,
+  ];
+}
+
+List<MutationOperation> _removeActive(
+  List<MutationOperation> active,
+  OperationId operationId,
+) {
+  return active
+      .where((operation) => operation.operationId != operationId)
+      .toList(growable: false);
+}
+
+_PathLookup _readJsonPath(Object? root, String path) {
+  var current = root;
+  for (final segment in _pathSegments(path)) {
+    if (current is! Map<Object?, Object?> || !current.containsKey(segment)) {
+      return const _PathLookup(found: false, value: null);
+    }
+    current = current[segment];
+  }
+  return _PathLookup(found: true, value: current);
+}
+
+Object? _writeJsonPath(Object? root, String path, Object? value) {
+  final segments = _pathSegments(path);
+  if (root is! Map<Object?, Object?>) {
+    throw const InvalidMutationPayloadException(
+      'Child variables must be a JSON object for parent binding',
+    );
+  }
+  final result = _copyJsonMap(root);
+  var current = result;
+  for (var index = 0; index < segments.length; index++) {
+    final segment = segments[index];
+    if (index == segments.length - 1) {
+      current[segment] = value;
+      break;
+    }
+    final existing = current[segment];
+    if (existing == null) {
+      final next = <String, Object?>{};
+      current[segment] = next;
+      current = next;
+    } else if (existing is Map<Object?, Object?>) {
+      final next = _copyJsonMap(existing);
+      current[segment] = next;
+      current = next;
+    } else {
+      throw const InvalidMutationPayloadException(
+        'Child variable path crosses a non-object value',
+      );
+    }
+  }
+  return result;
+}
+
+List<String> _pathSegments(String path) {
+  final segments = path.split('.');
+  if (segments.any((segment) => segment.trim().isEmpty)) {
+    throw const InvalidMutationPayloadException(
+      'JSON path contains an empty segment',
+    );
+  }
+  return segments.map((segment) => segment.trim()).toList(growable: false);
+}
+
+bool _isValidJsonPath(String path) {
+  return path.split('.').every((segment) => segment.trim().isNotEmpty);
+}
+
+Map<String, Object?> _copyJsonMap(Map<Object?, Object?> value) {
+  final result = <String, Object?>{};
+  for (final entry in value.entries) {
+    final key = entry.key;
+    if (key is! String) {
+      throw const InvalidMutationPayloadException(
+        'JSON object keys must be strings',
+      );
+    }
+    result[key] = _copyJsonValue(entry.value);
+  }
+  return result;
+}
+
+Object? _copyJsonValue(Object? value) {
+  if (value is Map<Object?, Object?>) return _copyJsonMap(value);
+  if (value is List<Object?>) {
+    return value.map(_copyJsonValue).toList(growable: false);
+  }
+  return value;
+}

--- a/packages/fasq/lib/src/mutation/sync_engine/store/outbox_models.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/store/outbox_models.dart
@@ -255,6 +255,7 @@ MutationOperation _copyOperation(MutationOperation operation) {
     lineageId: operation.lineageId,
     authPolicy: operation.authPolicy,
     state: operation.state,
+    priority: operation.priority,
     authScope: operation.authScope,
     dependencies: List.unmodifiable(operation.dependencies),
     projections: List.unmodifiable(operation.projections),

--- a/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/mutation_contracts_test.dart
@@ -233,6 +233,56 @@ void main() {
     });
   });
 
+  group('MutationRegistrationRegistry result contracts', () {
+    test('encodes executor results with a registered result encoder', () async {
+      final registry = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'todos', name: 'create');
+      registry.register<String, String>(
+        key: key,
+        codec: JsonMutationCodec<String>(
+          encoder: (value) => value,
+          decoder: (payload) {
+            if (payload is! String) {
+              throw const InvalidMutationPayloadException('Expected string');
+            }
+            return payload;
+          },
+        ),
+        mutationFn: (value) async => 'created:$value',
+        resultEncoder: (value) => <String, Object?>{'result': value},
+      );
+
+      expect(
+        await registry.execute(key, 'todo'),
+        <String, Object?>{'result': 'created:todo'},
+      );
+    });
+
+    test('rejects executor results that cannot be JSON encoded', () async {
+      final registry = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'todos', name: 'create');
+      registry.register<String, String>(
+        key: key,
+        codec: JsonMutationCodec<String>(
+          encoder: (value) => value,
+          decoder: (payload) {
+            if (payload is! String) {
+              throw const InvalidMutationPayloadException('Expected string');
+            }
+            return payload;
+          },
+        ),
+        mutationFn: (value) async => 'created:$value',
+        resultEncoder: (_) => DateTime.utc(2026, 8, 19),
+      );
+
+      expect(
+        () => registry.execute(key, 'todo'),
+        throwsA(isA<InvalidMutationResultException>()),
+      );
+    });
+  });
+
   test('registers an executor without persisting the closure', () async {
     final registry = MutationRegistrationRegistry();
     final key = MutationKey(namespace: 'todos', name: 'create');

--- a/packages/fasq/test/mutation/sync_engine/replay/replay_coordinator_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/replay/replay_coordinator_test.dart
@@ -1,0 +1,759 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
+import 'package:fasq/src/mutation/sync_engine/replay/replay_coordinator.dart';
+import 'package:fasq/src/mutation/sync_engine/store/file_durable_outbox.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_models.dart';
+import 'package:fasq/src/security/outbox_encryption.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory directory;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('fasq-replay-test-');
+  });
+
+  tearDown(() async {
+    if (directory.existsSync()) await directory.delete(recursive: true);
+  });
+
+  test(
+    'replays dependencies in order and persists parent bindings first',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final parentKey = MutationKey(namespace: 'test', name: 'createTodo');
+      final childKey = MutationKey(namespace: 'test', name: 'updateTodo');
+      final independentKey = MutationKey(
+        namespace: 'test',
+        name: 'refreshTodos',
+      );
+      final executed = <String>[];
+      Object? variablesAtExecution;
+
+      registrations
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: parentKey,
+          codec: _mapCodec,
+          mutationFn: (_) async {
+            executed.add('parent');
+            return <String, Object?>{'id': 'todo-1'};
+          },
+        )
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: childKey,
+          codec: _mapCodec,
+          mutationFn: (variables) async {
+            executed.add('child');
+            variablesAtExecution = store.snapshot.active
+                .singleWhere(
+                  (operation) =>
+                      operation.operationId.value == 'child-operation',
+                )
+                .variables;
+            expect(variables['todoId'], 'todo-1');
+            return <String, Object?>{'updated': true};
+          },
+        )
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: independentKey,
+          codec: _mapCodec,
+          mutationFn: (_) async {
+            executed.add('independent');
+            return <String, Object?>{'refreshed': true};
+          },
+        );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [
+            _operation(
+              'parent-operation',
+              key: parentKey,
+              priority: 2,
+            ),
+            _operation(
+              'child-operation',
+              key: childKey,
+              priority: 1,
+              variables: {'todoId': 'placeholder'},
+              dependencies: [
+                MutationDependency(
+                  parentOperationId: OperationId('parent-operation'),
+                  parentResultPath: 'id',
+                  childVariablePath: 'todoId',
+                ),
+              ],
+            ),
+            _operation(
+              'independent-operation',
+              key: independentKey,
+            ),
+          ],
+        ),
+      );
+
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await coordinator.open();
+      final report = await coordinator.replay();
+
+      expect(executed, ['parent', 'child', 'independent']);
+      expect(report.executedOperationIds.map((id) => id.value), [
+        'parent-operation',
+        'child-operation',
+        'independent-operation',
+      ]);
+      expect(variablesAtExecution, {'todoId': 'todo-1'});
+      expect(store.snapshot.active, isEmpty);
+      expect(
+        store.snapshot.history.map((entry) => entry.operationId.value),
+        containsAll(<String>[
+          'parent-operation',
+          'child-operation',
+          'independent-operation',
+        ]),
+      );
+      await coordinator.close();
+    },
+  );
+
+  test(
+    'blocks descendants after terminal parent failure but runs independent '
+    'work',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final parentKey = MutationKey(namespace: 'test', name: 'failingParent');
+      final childKey = MutationKey(namespace: 'test', name: 'dependentChild');
+      final independentKey = MutationKey(
+        namespace: 'test',
+        name: 'independent',
+      );
+      var childInvocations = 0;
+      var independentInvocations = 0;
+
+      registrations
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: parentKey,
+          codec: _mapCodec,
+          mutationFn: (_) async => throw StateError('expected failure'),
+        )
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: childKey,
+          codec: _mapCodec,
+          mutationFn: (_) async {
+            childInvocations++;
+            return <String, Object?>{};
+          },
+        )
+        ..register<Map<String, Object?>, Map<String, Object?>>(
+          key: independentKey,
+          codec: _mapCodec,
+          mutationFn: (_) async {
+            independentInvocations++;
+            return <String, Object?>{};
+          },
+        );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [
+            _operation('parent', key: parentKey, priority: 2),
+            _operation(
+              'child',
+              key: childKey,
+              dependencies: [
+                MutationDependency(parentOperationId: OperationId('parent')),
+              ],
+            ),
+            _operation('independent', key: independentKey, priority: 1),
+          ],
+        ),
+      );
+
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await coordinator.open();
+      final report = await coordinator.replay();
+
+      expect(childInvocations, 0);
+      expect(independentInvocations, 1);
+      expect(report.failedOperationIds.map((id) => id.value), ['parent']);
+      expect(
+        store.snapshot.deadLetters.single.operation.operationId.value,
+        'parent',
+      );
+      expect(
+        store.snapshot.deadLetters.single.operation.state,
+        MutationOperationState.unknownOutcome,
+      );
+      expect(
+        store.snapshot.active
+            .singleWhere((operation) => operation.operationId.value == 'child')
+            .state,
+        MutationOperationState.blocked,
+      );
+      expect(
+        report.blockedOperations
+            .singleWhere(
+              (diagnostic) => diagnostic.operationId.value == 'child',
+            )
+            .reason,
+        ReplayBlockReason.parentFailure,
+      );
+      await coordinator.close();
+    },
+  );
+
+  test('persists missing, cycle, and registration diagnostics', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'registered');
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async => <String, Object?>{},
+    );
+
+    await store.open();
+    await store.transact(
+      (current) => current.copyWith(
+        active: [
+          _operation(
+            'missing',
+            key: key,
+            dependencies: [
+              MutationDependency(parentOperationId: OperationId('absent')),
+            ],
+          ),
+          _operation(
+            'cycle-a',
+            key: key,
+            dependencies: [
+              MutationDependency(parentOperationId: OperationId('cycle-b')),
+            ],
+          ),
+          _operation(
+            'cycle-b',
+            key: key,
+            dependencies: [
+              MutationDependency(parentOperationId: OperationId('cycle-a')),
+            ],
+          ),
+          _operation(
+            'unregistered',
+            key: MutationKey(namespace: 'test', name: 'missing'),
+          ),
+        ],
+      ),
+    );
+
+    final coordinator = DurableReplayCoordinator(
+      store: store,
+      registrations: registrations,
+    );
+    await coordinator.open();
+    final report = await coordinator.replay();
+    final diagnostics = {
+      for (final diagnostic in report.blockedOperations)
+        diagnostic.operationId.value: diagnostic.reason,
+    };
+
+    expect(diagnostics['missing'], ReplayBlockReason.missingDependency);
+    expect(diagnostics['cycle-a'], ReplayBlockReason.cycle);
+    expect(diagnostics['cycle-b'], ReplayBlockReason.cycle);
+    expect(
+      diagnostics['unregistered'],
+      ReplayBlockReason.missingRegistration,
+    );
+    expect(store.snapshot.metadata['replayDiagnostics'], isNotEmpty);
+    expect(
+      store.snapshot.active.every(
+        (operation) => operation.state == MutationOperationState.blocked,
+      ),
+      isTrue,
+    );
+    await coordinator.close();
+  });
+
+  test('recovers leftover running work as unknown outcome', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'running');
+    var invocations = 0;
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async {
+        invocations++;
+        return <String, Object?>{};
+      },
+    );
+
+    await store.open();
+    await store.transact(
+      (current) => current.copyWith(
+        active: [
+          _operation(
+            'running',
+            key: key,
+            state: MutationOperationState.running,
+          ),
+        ],
+      ),
+    );
+    await store.close();
+
+    final recoveredStore = _newStore(directory);
+    final coordinator = DurableReplayCoordinator(
+      store: recoveredStore,
+      registrations: registrations,
+    );
+    await coordinator.open();
+    final report = await coordinator.replay();
+
+    expect(report.recoveredUnknownOutcomeIds.map((id) => id.value), [
+      'running',
+    ]);
+    expect(invocations, 0);
+    expect(recoveredStore.snapshot.active, isEmpty);
+    expect(
+      recoveredStore.snapshot.deadLetters.single.operation.state,
+      MutationOperationState.unknownOutcome,
+    );
+    await coordinator.close();
+  });
+
+  test(
+    'blocks duplicate operation IDs and one-sided bindings',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'registered');
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (_) async => <String, Object?>{},
+      );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [
+            _operation('duplicate', key: key),
+            _operation('duplicate', key: key),
+            _operation(
+              'invalid-binding',
+              key: key,
+              dependencies: [
+                MutationDependency(
+                  parentOperationId: OperationId('parent'),
+                  parentResultPath: 'id',
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await coordinator.open();
+      final report = await coordinator.replay();
+      final reasons = {
+        for (final diagnostic in report.blockedOperations)
+          diagnostic.operationId.value: diagnostic.reason,
+      };
+
+      expect(reasons['duplicate'], ReplayBlockReason.duplicateOperation);
+      expect(reasons['invalid-binding'], ReplayBlockReason.invalidBinding);
+      await coordinator.close();
+    },
+  );
+
+  test('blocks active operation IDs already in terminal ledgers', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'registered');
+    var invocations = 0;
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async {
+        invocations++;
+        return <String, Object?>{};
+      },
+    );
+
+    final operationId = OperationId('terminal-operation');
+    final terminalOperation = _operation(
+      operationId.value,
+      key: key,
+      state: MutationOperationState.failedTerminal,
+    );
+    await store.open();
+    await store.transact(
+      (current) => current.copyWith(
+        active: [_operation(operationId.value, key: key)],
+        history: [
+          OutboxHistoryEntry.validated(
+            operationId: operationId,
+            state: MutationOperationState.failedTerminal,
+            completedAt: DateTime.utc(2026),
+          ),
+        ],
+        deadLetters: [
+          OutboxDeadLetter(
+            operation: terminalOperation,
+            category: MutationFailureCategory.business,
+            messageKey: 'sync.replay.failure.business',
+            retryable: false,
+            repairable: true,
+            failedAt: DateTime.utc(2026),
+          ),
+        ],
+      ),
+    );
+
+    final coordinator = DurableReplayCoordinator(
+      store: store,
+      registrations: registrations,
+    );
+    await coordinator.open();
+    final report = await coordinator.replay();
+
+    expect(invocations, 0);
+    expect(
+      report.blockedOperations.single.reason,
+      ReplayBlockReason.duplicateOperation,
+    );
+    expect(store.snapshot.active.single.state, MutationOperationState.blocked);
+    await coordinator.close();
+  });
+
+  test(
+    'does not satisfy a child from history when active ID is duplicated',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'registered');
+      var invocations = 0;
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (_) async {
+          invocations++;
+          return <String, Object?>{};
+        },
+      );
+
+      final operationId = OperationId('duplicate-parent');
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [
+            _operation(operationId.value, key: key),
+            _operation(
+              'dependent',
+              key: key,
+              dependencies: [
+                MutationDependency(parentOperationId: operationId),
+              ],
+            ),
+          ],
+          history: [
+            OutboxHistoryEntry.validated(
+              operationId: operationId,
+              state: MutationOperationState.succeeded,
+              completedAt: DateTime.utc(2026),
+            ),
+          ],
+        ),
+      );
+
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await coordinator.open();
+      final report = await coordinator.replay();
+
+      expect(invocations, 0);
+      expect(
+        report.blockedOperations
+            .singleWhere(
+              (diagnostic) => diagnostic.operationId.value == 'dependent',
+            )
+            .reason,
+        ReplayBlockReason.duplicateOperation,
+      );
+      await coordinator.close();
+    },
+  );
+
+  test('preserves all missing and related dependency IDs', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'registered');
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async => <String, Object?>{},
+    );
+
+    await store.open();
+    await store.transact(
+      (current) => current.copyWith(
+        active: [
+          _operation(
+            'blocked',
+            key: key,
+            dependencies: [
+              MutationDependency(
+                parentOperationId: OperationId('missing-a'),
+              ),
+              MutationDependency(
+                parentOperationId: OperationId('missing-b'),
+              ),
+              MutationDependency(
+                parentOperationId: OperationId('invalid-a'),
+                parentResultPath: 'id',
+              ),
+              MutationDependency(
+                parentOperationId: OperationId('invalid-b'),
+                parentResultPath: 'id',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    final coordinator = DurableReplayCoordinator(
+      store: store,
+      registrations: registrations,
+    );
+    await coordinator.open();
+    final report = await coordinator.replay();
+    final diagnostic = report.blockedOperations.single;
+
+    expect(diagnostic.reason, ReplayBlockReason.invalidBinding);
+    expect(diagnostic.missingDependencyIds, ['missing-a', 'missing-b']);
+    expect(diagnostic.relatedOperationIds, [
+      OperationId('invalid-a'),
+      OperationId('invalid-b'),
+    ]);
+    await coordinator.close();
+  });
+
+  test(
+    'prevents duplicate execution through two coordinators sharing a store',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'slow');
+      final started = Completer<void>();
+      final release = Completer<void>();
+      var invocations = 0;
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (_) async {
+          invocations++;
+          started.complete();
+          await release.future;
+          return <String, Object?>{};
+        },
+      );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(active: [_operation('slow', key: key)]),
+      );
+      final first = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      final second = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await first.open();
+      await second.open();
+
+      final firstReplay = first.replay();
+      await started.future;
+      final secondReplay = second.replay();
+      release.complete();
+      await Future.wait([firstReplay, secondReplay]);
+
+      expect(invocations, 1);
+      await first.close();
+      await second.close();
+    },
+  );
+
+  test('leaves running work when completion generation conflicts', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'conflicting');
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async {
+        await store.transact(
+          (current) => current.copyWith(
+            metadata: {'externalWrite': true},
+          ),
+        );
+        return <String, Object?>{'ok': true};
+      },
+    );
+
+    await store.open();
+    await store.transact(
+      (current) =>
+          current.copyWith(active: [_operation('conflicting', key: key)]),
+    );
+    final coordinator = DurableReplayCoordinator(
+      store: store,
+      registrations: registrations,
+    );
+    await coordinator.open();
+
+    await expectLater(
+      coordinator.replay(),
+      throwsA(isA<OutboxGenerationConflictException>()),
+    );
+    expect(store.snapshot.active.single.state, MutationOperationState.running);
+    expect(store.snapshot.history, isEmpty);
+    expect(store.snapshot.deadLetters, isEmpty);
+    await coordinator.close();
+  });
+
+  test('does not open a second coordinator for another store owner', () async {
+    final firstStore = _newStore(directory);
+    final secondStore = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final first = DurableReplayCoordinator(
+      store: firstStore,
+      registrations: registrations,
+    );
+    final second = DurableReplayCoordinator(
+      store: secondStore,
+      registrations: registrations,
+    );
+
+    await first.open();
+    await expectLater(
+      second.open(),
+      throwsA(isA<OutboxOwnershipException>()),
+    );
+    await first.close();
+  });
+
+  test('replay result collections cannot be mutated by callers', () {
+    final operationId = OperationId('immutable');
+    final diagnostic = ReplayDiagnostic(
+      operationId: operationId,
+      reason: ReplayBlockReason.missingDependency,
+      messageKey: 'sync.replay.missing_dependency',
+      missingDependencyIds: ['missing'],
+    );
+    final report = ReplayRunResult(
+      executedOperationIds: [operationId],
+      failedOperationIds: const [],
+      recoveredUnknownOutcomeIds: const [],
+      blockedOperations: [diagnostic],
+    );
+
+    expect(
+      () => report.executedOperationIds.add(OperationId('another')),
+      throwsUnsupportedError,
+    );
+    expect(
+      () => report.blockedOperations.add(diagnostic),
+      throwsUnsupportedError,
+    );
+    expect(
+      () => diagnostic.missingDependencyIds.add('another'),
+      throwsUnsupportedError,
+    );
+  });
+}
+
+const _mapCodec = JsonMutationCodec<Map<String, Object?>>(
+  encoder: _encodeMap,
+  decoder: _decodeMap,
+);
+
+Map<String, Object?> _encodeMap(Map<String, Object?> value) => value;
+
+Map<String, Object?> _decodeMap(Object? value) {
+  if (value is! Map<Object?, Object?>) {
+    throw const FormatException('Expected a JSON object');
+  }
+  return <String, Object?>{
+    for (final entry in value.entries)
+      if (entry.key is String) entry.key! as String: entry.value,
+  };
+}
+
+FileDurableOutbox _newStore(Directory directory) {
+  return FileDurableOutbox(
+    directoryPath: directory.path,
+    encryption: const _FakeOutboxEncryption(),
+  );
+}
+
+MutationOperation _operation(
+  String id, {
+  required MutationKey key,
+  Object? variables = const <String, Object?>{},
+  List<MutationDependency> dependencies = const <MutationDependency>[],
+  MutationOperationState state = MutationOperationState.pending,
+  int priority = 0,
+}) {
+  return MutationOperation(
+    operationId: OperationId(id),
+    mutationKey: key,
+    variables: variables,
+    createdAt: DateTime.utc(2026),
+    idempotencyKey: IdempotencyKey('idempotency-$id'),
+    lineageId: LineageId('lineage-$id'),
+    authPolicy: AuthPolicy.none,
+    state: state,
+    priority: priority,
+    dependencies: dependencies,
+  );
+}
+
+class _FakeOutboxEncryption implements OutboxEncryption {
+  const _FakeOutboxEncryption();
+
+  @override
+  Future<void> prepare({required bool allowCreateKey}) async {}
+
+  @override
+  Future<List<int>> encrypt(List<int> plaintext) async =>
+      plaintext.map((byte) => byte ^ 0xAA).toList(growable: false);
+
+  @override
+  Future<List<int>> decrypt(List<int> ciphertext) async =>
+      ciphertext.map((byte) => byte ^ 0xAA).toList(growable: false);
+}


### PR DESCRIPTION
## Summary
- add durable dependency-aware replay with deterministic Kahn ordering
- persist parent-result bindings before child execution and recover interrupted work as unknown outcome
- enforce generation-safe single-worker claims, graph diagnostics, duplicate identity checks, and JSON-safe result encoding

## Verification
- flutter analyze packages/fasq/lib/src/mutation/sync_engine packages/fasq/lib/fasq.dart packages/fasq/test/mutation/sync_engine
- flutter test packages/fasq/test/mutation
- dart format on touched Dart files
- git diff --check

## Scope
Retry policy, auth refresh, lifecycle triggers, cache projections, and public legacy queue integration remain outside this change.