### PR TITLE
fix(sync): close replay lifecycle safety gaps

### DIFF
--- a/packages/fasq/lib/src/mutation/sync_engine/execution/auth_session.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/execution/auth_session.dart
@@ -104,15 +104,22 @@ class AuthScopeGate {
     }
     final expectedScope = operation.authScope;
     final currentScope = session.scope;
+    if (session.status == AuthSessionStatus.signedOut) {
+      return expectedScope == null
+          ? AuthExecutionDecision.blocked
+          : AuthExecutionDecision.quarantined;
+    }
     if (session.status == AuthSessionStatus.revoked) {
       return AuthExecutionDecision.quarantined;
     }
-    if (session.status != AuthSessionStatus.ready ||
-        expectedScope == null ||
-        currentScope != expectedScope) {
-      return currentScope == null || currentScope == expectedScope
-          ? AuthExecutionDecision.blocked
-          : AuthExecutionDecision.quarantined;
+    if (session.status != AuthSessionStatus.ready) {
+      return AuthExecutionDecision.blocked;
+    }
+    if (expectedScope == null || currentScope == null) {
+      return AuthExecutionDecision.blocked;
+    }
+    if (currentScope != expectedScope) {
+      return AuthExecutionDecision.quarantined;
     }
     return AuthExecutionDecision.allowed;
   }

--- a/packages/fasq/lib/src/mutation/sync_engine/lifecycle/replay_lifecycle.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/lifecycle/replay_lifecycle.dart
@@ -155,9 +155,12 @@ class ReplayLifecycleController {
       _onConnectivityChanged,
     );
     _readiness.update(connectivityReady: resolvedNetworkStatus.isOnline);
-    if (authSessionProvider != null) {
-      _authSubscription = authSessionProvider.changes.listen(_onAuthChanged);
-      unawaited(_resolveInitialAuth(authSessionProvider));
+    final provider = authSessionProvider;
+    if (provider == null) {
+      _readiness.update(authReady: true);
+    } else {
+      _authSubscription = provider.changes.listen(_onAuthChanged);
+      unawaited(_resolveInitialAuth(provider));
     }
   }
 

--- a/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/models/mutation_operation.dart
@@ -20,6 +20,10 @@ enum MutationOperationState {
   /// Operation waits for authentication readiness or reauthentication.
   authBlocked,
 
+  /// Operation was denied by the current authorization policy and needs
+  /// explicit repair or user action before it can run again.
+  authorizationBlocked,
+
   /// Operation is retained for its original scope after identity change.
   quarantined,
 

--- a/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
@@ -155,6 +155,7 @@ class DurableReplayCoordinator {
   bool _isOpen = false;
   List<OperationId> _recoveredUnknownOutcomeIds = const <OperationId>[];
   Map<String, DateTime> _rateLimitPauses = const <String, DateTime>{};
+  String? _lastServedRateLimitBucket;
 
   /// Opens the store and converts leftover running work into safe dead letters.
   Future<void> open() {
@@ -177,9 +178,17 @@ class DurableReplayCoordinator {
   }
 
   /// Replays all currently admissible work in deterministic order.
-  Future<ReplayRunResult> replay() {
+  ///
+  /// When [cancellationToken] is omitted, cancellation remains internal to
+  /// this replay request. A supplied token lets the caller stop future work
+  /// and lets cooperative adapters observe cancellation for active work.
+  Future<ReplayRunResult> replay({
+    ReplayCancellationToken? cancellationToken,
+  }) {
     return _serialized(() async {
       _requireOpen();
+      final replayCancellationToken =
+          cancellationToken ?? ReplayCancellationToken();
       final executed = <OperationId>[];
       final failed = <OperationId>[];
       final scheduledRetries = <OperationId>[];
@@ -191,6 +200,7 @@ class DurableReplayCoordinator {
       await _applySchedulingLimits();
       await _clearDiagnostics();
       while (true) {
+        if (replayCancellationToken.isCancelled) break;
         final selection = _select(_store.snapshot);
         for (final diagnostic in selection.diagnostics) {
           _recordDiagnostic(blocked, diagnostic);
@@ -207,6 +217,7 @@ class DurableReplayCoordinator {
         final started = await _start(next);
         if (started == null) continue;
         final operation = started.operation;
+        _lastServedRateLimitBucket = operation.rateLimitBucket;
         executed.add(operation.operationId);
 
         final context = MutationExecutionContext(
@@ -215,7 +226,7 @@ class DurableReplayCoordinator {
           authPolicy: operation.authPolicy,
           authScope: operation.authScope,
           attempt: operation.attemptCount,
-          cancellationToken: ReplayCancellationToken(),
+          cancellationToken: replayCancellationToken,
         );
         MutationExecutionResult execution;
         try {
@@ -471,8 +482,12 @@ class DurableReplayCoordinator {
         )
         .toList(growable: false);
 
-    final resolution = const KahnDagSorter<MutationOperation>(
-      readyNodeComparator: _compareReadyNodes,
+    final resolution = KahnDagSorter<MutationOperation>(
+      readyNodeComparator: (left, right) => _compareReadyNodes(
+        left,
+        right,
+        preferredBucket: _lastServedRateLimitBucket,
+      ),
     ).resolve(candidates);
     final diagnostics = <ReplayDiagnostic>[...directDiagnostics.values];
     for (final blockedNode in resolution.blockedNodes) {
@@ -841,9 +856,13 @@ class DurableReplayCoordinator {
   }
 
   MutationOperationState _pauseStateFor(MutationAdapterFailure failure) {
-    return failure.category == MutationFailureCategory.authentication
-        ? MutationOperationState.authBlocked
-        : MutationOperationState.paused;
+    return switch (failure.category) {
+      MutationFailureCategory.authentication =>
+        MutationOperationState.authBlocked,
+      MutationFailureCategory.authorization =>
+        MutationOperationState.authorizationBlocked,
+      _ => MutationOperationState.paused,
+    };
   }
 
   Map<String, DateTime> _readRateLimitPauses(Map<String, Object?> metadata) {
@@ -1102,8 +1121,16 @@ List<ReplayDiagnostic> _deduplicateDiagnostics(
 
 int _compareReadyNodes(
   SyncDagNode<MutationOperation> left,
-  SyncDagNode<MutationOperation> right,
-) {
+  SyncDagNode<MutationOperation> right, {
+  String? preferredBucket,
+}) {
+  if (preferredBucket != null) {
+    final leftIsPreferred = left.payload.rateLimitBucket == preferredBucket;
+    final rightIsPreferred = right.payload.rateLimitBucket == preferredBucket;
+    if (leftIsPreferred != rightIsPreferred) {
+      return leftIsPreferred ? 1 : -1;
+    }
+  }
   final priority = right.payload.priority.compareTo(left.payload.priority);
   if (priority != 0) return priority;
   final createdAt = left.payload.createdAt.compareTo(right.payload.createdAt);

--- a/packages/fasq/test/mutation/sync_engine/replay/replay_coordinator_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/replay/replay_coordinator_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/execution/execution_context.dart';
 import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
 import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
 import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
@@ -122,6 +123,195 @@ void main() {
           'child-operation',
           'independent-operation',
         ]),
+      );
+      await coordinator.close();
+    },
+  );
+
+  test('pre-execution cancellation does not invoke an executor', () async {
+    final store = _newStore(directory);
+    final registrations = MutationRegistrationRegistry();
+    final key = MutationKey(namespace: 'test', name: 'cancelled');
+    var invocations = 0;
+    registrations.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (_) async {
+        invocations++;
+        return <String, Object?>{};
+      },
+    );
+
+    await store.open();
+    await store.transact(
+      (current) => current.copyWith(
+        active: [_operation('cancelled', key: key)],
+      ),
+    );
+    final coordinator = DurableReplayCoordinator(
+      store: store,
+      registrations: registrations,
+    );
+    await coordinator.open();
+    final cancellationToken = ReplayCancellationToken()..cancel();
+
+    final report = await coordinator.replay(
+      cancellationToken: cancellationToken,
+    );
+
+    expect(invocations, 0);
+    expect(report.executedOperationIds, isEmpty);
+    expect(store.snapshot.active.single.state, MutationOperationState.pending);
+    await coordinator.close();
+  });
+
+  test(
+    'supplied cancellation reaches context and safely pauses in-flight work',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'cooperativeCancel');
+      final adapter = _BlockingExecutionAdapter();
+      var invocations = 0;
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (_) async {
+          invocations++;
+          return <String, Object?>{};
+        },
+      );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [_operation('cooperative-cancel', key: key)],
+        ),
+      );
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+        executionAdapter: adapter,
+      );
+      await coordinator.open();
+      final cancellationToken = ReplayCancellationToken();
+      final replay = coordinator.replay(
+        cancellationToken: cancellationToken,
+      );
+
+      final context = await adapter.contextSeen.future;
+      expect(identical(context.cancellationToken, cancellationToken), isTrue);
+      cancellationToken.cancel();
+      adapter.release();
+
+      final report = await replay;
+
+      expect(invocations, 0);
+      expect(report.failedOperationIds.map((id) => id.value), [
+        'cooperative-cancel',
+      ]);
+      expect(
+        store.snapshot.active.single.state,
+        MutationOperationState.paused,
+      );
+      await coordinator.close();
+    },
+  );
+
+  test(
+    'rotates ready rate-limit buckets between otherwise equal work',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'fairness');
+      final executed = <String>[];
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async {
+          executed.add(variables['id']! as String);
+          return <String, Object?>{};
+        },
+      );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [
+            _operation(
+              'a-1',
+              key: key,
+              variables: {'id': 'a-1'},
+              rateLimitBucket: 'a',
+            ),
+            _operation(
+              'a-2',
+              key: key,
+              variables: {'id': 'a-2'},
+              rateLimitBucket: 'a',
+            ),
+            _operation(
+              'b-1',
+              key: key,
+              variables: {'id': 'b-1'},
+              rateLimitBucket: 'b',
+            ),
+          ],
+        ),
+      );
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+      );
+      await coordinator.open();
+
+      await coordinator.replay();
+
+      expect(executed, ['a-1', 'b-1', 'a-2']);
+      await coordinator.close();
+    },
+  );
+
+  test(
+    'persists authorization denial as non-replayable repair state',
+    () async {
+      final store = _newStore(directory);
+      final registrations = MutationRegistrationRegistry();
+      final key = MutationKey(namespace: 'test', name: 'forbidden');
+      var adapterCalls = 0;
+      final adapter = _AuthorizationBlockingAdapter(
+        onExecute: () => adapterCalls++,
+      );
+      registrations.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (_) async => <String, Object?>{},
+      );
+
+      await store.open();
+      await store.transact(
+        (current) => current.copyWith(
+          active: [_operation('forbidden', key: key)],
+        ),
+      );
+      final coordinator = DurableReplayCoordinator(
+        store: store,
+        registrations: registrations,
+        executionAdapter: adapter,
+      );
+      await coordinator.open();
+
+      await coordinator.replay();
+      expect(
+        store.snapshot.active.single.state,
+        MutationOperationState.authorizationBlocked,
+      );
+      await coordinator.replay();
+
+      expect(adapterCalls, 1);
+      expect(
+        store.snapshot.active.single.state,
+        MutationOperationState.authorizationBlocked,
       );
       await coordinator.close();
     },
@@ -726,6 +916,7 @@ MutationOperation _operation(
   required MutationKey key,
   Object? variables = const <String, Object?>{},
   List<MutationDependency> dependencies = const <MutationDependency>[],
+  String? rateLimitBucket,
   MutationOperationState state = MutationOperationState.pending,
   int priority = 0,
   Duration maxAge = const Duration(days: 3650),
@@ -742,6 +933,7 @@ MutationOperation _operation(
     priority: priority,
     maxAge: maxAge,
     dependencies: dependencies,
+    rateLimitBucket: rateLimitBucket,
   );
 }
 
@@ -758,4 +950,42 @@ class _FakeOutboxEncryption implements OutboxEncryption {
   @override
   Future<List<int>> decrypt(List<int> ciphertext) async =>
       ciphertext.map((byte) => byte ^ 0xAA).toList(growable: false);
+}
+
+class _BlockingExecutionAdapter implements MutationExecutionAdapter {
+  final contextSeen = Completer<MutationExecutionContext>();
+  final _release = Completer<void>();
+
+  @override
+  Future<MutationExecutionResult> execute(
+    MutationExecutionContext context,
+    Future<Object?> Function() executor,
+  ) async {
+    contextSeen.complete(context);
+    await _release.future;
+    return const DirectMutationExecutionAdapter().execute(context, executor);
+  }
+
+  void release() => _release.complete();
+}
+
+class _AuthorizationBlockingAdapter implements MutationExecutionAdapter {
+  _AuthorizationBlockingAdapter({required this.onExecute});
+
+  final void Function() onExecute;
+
+  @override
+  Future<MutationExecutionResult> execute(
+    MutationExecutionContext context,
+    Future<Object?> Function() executor,
+  ) async {
+    onExecute();
+    return const MutationExecutionFailure(
+      MutationAdapterFailure(
+        category: MutationFailureCategory.authorization,
+        messageKey: 'sync.replay.authorization_denied',
+        disposition: MutationFailureDisposition.pause,
+      ),
+    );
+  }
 }

--- a/packages/fasq/test/mutation/sync_engine/transport_retry_auth_lifecycle_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/transport_retry_auth_lifecycle_test.dart
@@ -84,6 +84,24 @@ void main() {
         ),
         AuthExecutionDecision.blocked,
       );
+      expect(
+        gate.evaluate(operation, const AuthSessionSnapshot.signedOut()),
+        AuthExecutionDecision.quarantined,
+      );
+      expect(
+        gate.evaluate(
+          operation,
+          AuthSessionSnapshot(
+            status: AuthSessionStatus.reauthenticationRequired,
+            scope: AuthScope(
+              principalId: 'user-2',
+              tenantId: 'tenant-1',
+              authRealm: 'primary',
+            ),
+          ),
+        ),
+        AuthExecutionDecision.blocked,
+      );
     });
 
     test('rejects invalid authentication state combinations', () {
@@ -193,6 +211,35 @@ void main() {
   });
 
   group('Lifecycle bridge', () {
+    test(
+      'assumes auth readiness when no auth provider is configured',
+      () async {
+        final readiness = ReplayReadinessBarrier(
+          initial: const ReplayReadiness(
+            storeReady: true,
+            registrationsReady: true,
+            encryptionReady: true,
+            connectivityReady: true,
+          ),
+        );
+        var replayCalls = 0;
+        final controller = ReplayLifecycleController(
+          readiness: readiness,
+          replay: () async {
+            replayCalls++;
+            return _emptyReplayResult();
+          },
+        );
+
+        await controller.onStartup().timeout(const Duration(seconds: 1));
+
+        expect(readiness.current.authReady, isTrue);
+        expect(replayCalls, 1);
+        await controller.dispose();
+        await readiness.dispose();
+      },
+    );
+
     test('coalesces concurrent lifecycle requests into one replay', () async {
       final readiness = ReplayReadinessBarrier(
         initial: const ReplayReadiness(
@@ -307,6 +354,8 @@ void main() {
         },
       );
 
+      await Future<void>.delayed(Duration.zero);
+      expect(readiness.current.authReady, isFalse);
       auth.update(AuthSessionSnapshot.ready(scope));
       await replayStarted.future;
       expect(replayCalls, 1);


### PR DESCRIPTION
## Summary
- make lifecycle replay ready when no auth provider is configured
- quarantine authenticated work on logout/signed-out sessions
- expose caller-controlled replay cancellation
- rotate ready rate-limit buckets for fair admission
- persist authorization denials as `authorizationBlocked`
- add regression coverage for each behavior

## Verification
- `dart analyze packages/fasq/lib/src/mutation/sync_engine packages/fasq/test/mutation/sync_engine`
- `flutter test packages/fasq/test/mutation/sync_engine` (73 passed)
- `dart format ...`
- `git diff --check`

Full package suite was not used as the gate because it has unrelated pre-existing query/observability failures on the base branch.