### PR TITLE
feat(sync): integrate public durable mutation queue

### DIFF
--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -24,6 +24,7 @@ export 'src/client/query_client_observer.dart';
 export 'src/memory/memory_pressure_handler.dart';
 export 'src/mutation/mutation.dart';
 export 'src/mutation/durable_mutation_queue.dart';
+export 'src/mutation/legacy_mutation_migration.dart';
 export 'src/mutation/mutation_meta.dart';
 export 'src/mutation/mutation_options.dart';
 export 'src/mutation/mutation_snapshot.dart';

--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -23,6 +23,7 @@ export 'src/client/query_client.dart';
 export 'src/client/query_client_observer.dart';
 export 'src/memory/memory_pressure_handler.dart';
 export 'src/mutation/mutation.dart';
+export 'src/mutation/durable_mutation_queue.dart';
 export 'src/mutation/mutation_meta.dart';
 export 'src/mutation/mutation_options.dart';
 export 'src/mutation/mutation_snapshot.dart';

--- a/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
+++ b/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
@@ -1,0 +1,271 @@
+import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/execution/auth_session.dart';
+import 'package:fasq/src/mutation/sync_engine/execution/execution_context.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
+import 'package:fasq/src/mutation/sync_engine/replay/replay_coordinator.dart';
+import 'package:fasq/src/mutation/sync_engine/replay/retry_policy.dart';
+import 'package:fasq/src/mutation/sync_engine/store/durable_outbox.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_models.dart';
+import 'package:uuid/uuid.dart';
+
+/// Public durable queue facade for registered mutation functions.
+///
+/// Registration uses the same mutation function that performs an immediate
+/// mutation. Queueing stores only its encoded variables and stable operation
+/// identity; replay resolves the function from the runtime registry.
+class DurableMutationQueue {
+  /// Creates a durable queue over [store].
+  factory DurableMutationQueue({
+    required DurableOutboxStore store,
+    MutationRegistrationRegistry? registrations,
+    DateTime Function()? now,
+    String Function()? idGenerator,
+    MutationExecutionAdapter? executionAdapter,
+    RetryPolicy retryPolicy = const RetryPolicy(),
+    AuthSessionProvider? authSessionProvider,
+    bool Function()? isOnline,
+  }) {
+    final resolvedRegistrations =
+        registrations ?? MutationRegistrationRegistry();
+    final resolvedNow = now ?? DateTime.now;
+    return DurableMutationQueue._(
+      store: store,
+      registrations: resolvedRegistrations,
+      now: resolvedNow,
+      idGenerator: idGenerator ?? _newUuid,
+      coordinator: DurableReplayCoordinator(
+        store: store,
+        registrations: resolvedRegistrations,
+        now: resolvedNow,
+        executionAdapter: executionAdapter,
+        retryPolicy: retryPolicy,
+        authSessionProvider: authSessionProvider,
+        isOnline: isOnline,
+      ),
+    );
+  }
+
+  DurableMutationQueue._({
+    required DurableOutboxStore store,
+    required MutationRegistrationRegistry registrations,
+    required DateTime Function() now,
+    required String Function() idGenerator,
+    required DurableReplayCoordinator coordinator,
+  }) : _store = store,
+       _registrations = registrations,
+       _now = now,
+       _idGenerator = idGenerator,
+       _coordinator = coordinator;
+
+  static const _uuid = Uuid();
+
+  final DurableOutboxStore _store;
+  final MutationRegistrationRegistry _registrations;
+  final DateTime Function() _now;
+  final String Function() _idGenerator;
+  final DurableReplayCoordinator _coordinator;
+  bool _isOpen = false;
+
+  /// Whether the queue currently owns an open durable store.
+  bool get isOpen => _isOpen;
+
+  /// Snapshot acknowledged by the durable store.
+  OutboxSnapshot get snapshot => _store.snapshot;
+
+  /// Current durable store generation.
+  int get generation => _store.generation;
+
+  /// Registers the existing immediate mutation function for durable replay.
+  ///
+  /// This is the only executor registration point. Replay never accepts a
+  /// second offline-only function.
+  void register<TData, TVariables>({
+    required MutationKey key,
+    required MutationCodec<TVariables> codec,
+    required Future<TData> Function(TVariables variables) mutationFn,
+    AuthPolicy authPolicy = AuthPolicy.none,
+    Object? Function(TData data)? resultEncoder,
+  }) {
+    _registrations.register<TData, TVariables>(
+      key: key,
+      codec: codec,
+      mutationFn: mutationFn,
+      authPolicy: authPolicy,
+      resultEncoder: resultEncoder,
+    );
+  }
+
+  /// Opens the queue and recovers interrupted durable work.
+  Future<void> open() async {
+    if (_isOpen) return;
+    try {
+      await _coordinator.open();
+      _isOpen = true;
+    } on DurableOutboxException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        const DurableMutationQueueStorageException(),
+        stackTrace,
+      );
+    }
+  }
+
+  /// Closes the queue and releases durable store ownership.
+  Future<void> close() async {
+    if (!_isOpen) return;
+    try {
+      await _coordinator.close();
+      _isOpen = false;
+    } on DurableOutboxException {
+      rethrow;
+    } on Object catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        const DurableMutationQueueStorageException(),
+        stackTrace,
+      );
+    }
+  }
+
+  /// Encodes and durably commits one pending mutation operation.
+  Future<DurableEnqueueAcknowledgement> enqueue<TVariables>({
+    required MutationKey key,
+    required TVariables variables,
+    OperationId? operationId,
+    IdempotencyKey? idempotencyKey,
+    LineageId? lineageId,
+    AuthScope? authScope,
+    DateTime? createdAt,
+    int priority = 0,
+    List<MutationDependency> dependencies = const <MutationDependency>[],
+    List<MutationProjectionDescriptor> projections =
+        const <MutationProjectionDescriptor>[],
+    int maxAttempts = 5,
+    Duration maxAge = const Duration(days: 30),
+    String? rateLimitBucket,
+  }) async {
+    _requireOpen();
+    final encodedVariables = _registrations.encodeVariables(key, variables);
+    final operation = MutationOperation(
+      operationId: operationId ?? OperationId(_idGenerator()),
+      mutationKey: key,
+      variables: encodedVariables,
+      createdAt: createdAt ?? _now(),
+      idempotencyKey: idempotencyKey ?? IdempotencyKey(_idGenerator()),
+      lineageId: lineageId ?? LineageId(_idGenerator()),
+      authPolicy: _registrations.authPolicyFor(key),
+      authScope: authScope,
+      state: MutationOperationState.pending,
+      priority: priority,
+      dependencies: dependencies,
+      projections: projections,
+      maxAttempts: maxAttempts,
+      maxAge: maxAge,
+      rateLimitBucket: rateLimitBucket,
+    );
+
+    final committed = await _commit((current) {
+      _rejectDuplicateIdentity(current, operation);
+      return current.copyWith(active: [...current.active, operation]);
+    });
+    final acknowledged = committed.active.firstWhere(
+      (item) => item.operationId == operation.operationId,
+    );
+    return DurableEnqueueAcknowledgement(acknowledged);
+  }
+
+  /// Explicitly replays all currently admissible durable work.
+  Future<ReplayRunResult> replay({
+    ReplayCancellationToken? cancellationToken,
+  }) => _coordinator.replay(cancellationToken: cancellationToken);
+
+  /// Compatibility alias for callers that previously requested queue work
+  /// through `processQueue`.
+  Future<ReplayRunResult> processQueue({
+    ReplayCancellationToken? cancellationToken,
+  }) => replay(cancellationToken: cancellationToken);
+
+  Future<OutboxSnapshot> _commit(DurableOutboxTransaction transaction) async {
+    try {
+      return await _store.transact(transaction);
+    } on DurableOutboxException {
+      rethrow;
+    } on MutationContractException {
+      rethrow;
+    } on Object catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        const DurableMutationQueueStorageException(),
+        stackTrace,
+      );
+    }
+  }
+
+  void _requireOpen() {
+    if (!_isOpen) {
+      throw StateError('The durable mutation queue is not open');
+    }
+  }
+
+  void _rejectDuplicateIdentity(
+    OutboxSnapshot snapshot,
+    MutationOperation operation,
+  ) {
+    final operationId = operation.operationId.value;
+    final idempotencyKey = operation.idempotencyKey.value;
+    final duplicateOperation =
+        [
+          ...snapshot.active,
+          ...snapshot.deadLetters.map((entry) => entry.operation),
+        ].any(
+          (existing) =>
+              existing.operationId.value == operationId ||
+              existing.idempotencyKey.value == idempotencyKey,
+        );
+    final duplicateHistory = snapshot.history.any(
+      (entry) => entry.operationId.value == operationId,
+    );
+    if (duplicateOperation || duplicateHistory) {
+      throw DuplicateMutationOperationException(operationId);
+    }
+  }
+
+  static String _newUuid() => _uuid.v4();
+}
+
+/// Durable acknowledgement returned after the enqueue transaction commits.
+class DurableEnqueueAcknowledgement {
+  /// Creates an acknowledgement for [operation].
+  const DurableEnqueueAcknowledgement(this.operation);
+
+  /// Operation snapshot acknowledged by durable storage.
+  final MutationOperation operation;
+
+  /// Stable operation occurrence identity.
+  OperationId get operationId => operation.operationId;
+
+  /// Stable retry/restart idempotency identity.
+  IdempotencyKey get idempotencyKey => operation.idempotencyKey;
+
+  /// Stable repair lineage identity.
+  LineageId get lineageId => operation.lineageId;
+}
+
+/// Safe typed storage failure raised when a backend returns an unknown error.
+class DurableMutationQueueStorageException extends DurableOutboxException {
+  /// Creates a generic queue storage failure.
+  const DurableMutationQueueStorageException()
+    : super(
+        DurableOutboxErrorCode.storage,
+        'The durable mutation queue storage operation failed',
+      );
+}
+
+/// Raised when an operation or idempotency identity is already retained.
+class DuplicateMutationOperationException extends MutationContractException {
+  /// Creates a duplicate-identity failure.
+  DuplicateMutationOperationException(String operationId)
+    : super('Mutation operation identity is already retained: $operationId');
+}

--- a/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
+++ b/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
@@ -91,6 +91,17 @@ class DurableMutationQueue {
         current.history.any((entry) => entry.operationId == operationId);
   }
 
+  /// Whether [idempotencyKey] is retained in active or dead-letter data.
+  bool hasRetainedIdempotencyKey(IdempotencyKey idempotencyKey) {
+    final current = _store.snapshot;
+    return current.active.any(
+          (item) => item.idempotencyKey == idempotencyKey,
+        ) ||
+        current.deadLetters.any(
+          (entry) => entry.operation.idempotencyKey == idempotencyKey,
+        );
+  }
+
   /// Registers the existing immediate mutation function for durable replay.
   ///
   /// This is the only executor registration point. Replay never accepts a
@@ -164,6 +175,10 @@ class DurableMutationQueue {
     String? rateLimitBucket,
   }) async {
     _requireOpen();
+    if (state != MutationOperationState.pending &&
+        state != MutationOperationState.retryScheduled) {
+      throw InvalidMutationEnqueueStateException(state);
+    }
     final encodedVariables = _registrations.encodeVariables(key, variables);
     final operation = MutationOperation(
       operationId: operationId ?? OperationId(_idGenerator()),
@@ -286,4 +301,11 @@ class DuplicateMutationOperationException extends MutationContractException {
   /// Creates a duplicate-identity failure.
   DuplicateMutationOperationException(String operationId)
     : super('Mutation operation identity is already retained: $operationId');
+}
+
+/// Raised when callers try to enqueue a non-replayable operation state.
+class InvalidMutationEnqueueStateException extends MutationContractException {
+  /// Creates an invalid enqueue-state failure.
+  InvalidMutationEnqueueStateException(MutationOperationState state)
+    : super('Mutation enqueue state is not replayable: ${state.name}');
 }

--- a/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
+++ b/packages/fasq/lib/src/mutation/durable_mutation_queue.dart
@@ -78,6 +78,19 @@ class DurableMutationQueue {
   /// Current durable store generation.
   int get generation => _store.generation;
 
+  /// Whether [key] has a runtime codec and executor registration.
+  bool hasRegistration(MutationKey key) => _registrations.contains(key);
+
+  /// Whether [operationId] is retained in active, dead-letter, or history data.
+  bool hasRetainedOperation(OperationId operationId) {
+    final current = _store.snapshot;
+    return current.active.any((item) => item.operationId == operationId) ||
+        current.deadLetters.any(
+          (entry) => entry.operation.operationId == operationId,
+        ) ||
+        current.history.any((entry) => entry.operationId == operationId);
+  }
+
   /// Registers the existing immediate mutation function for durable replay.
   ///
   /// This is the only executor registration point. Replay never accepts a
@@ -143,8 +156,11 @@ class DurableMutationQueue {
     List<MutationDependency> dependencies = const <MutationDependency>[],
     List<MutationProjectionDescriptor> projections =
         const <MutationProjectionDescriptor>[],
+    MutationOperationState state = MutationOperationState.pending,
+    int attemptCount = 0,
     int maxAttempts = 5,
     Duration maxAge = const Duration(days: 30),
+    DateTime? nextRunAt,
     String? rateLimitBucket,
   }) async {
     _requireOpen();
@@ -158,12 +174,14 @@ class DurableMutationQueue {
       lineageId: lineageId ?? LineageId(_idGenerator()),
       authPolicy: _registrations.authPolicyFor(key),
       authScope: authScope,
-      state: MutationOperationState.pending,
+      state: state,
       priority: priority,
       dependencies: dependencies,
       projections: projections,
+      attemptCount: attemptCount,
       maxAttempts: maxAttempts,
       maxAge: maxAge,
+      nextRunAt: nextRunAt,
       rateLimitBucket: rateLimitBucket,
     );
 

--- a/packages/fasq/lib/src/mutation/legacy_mutation_migration.dart
+++ b/packages/fasq/lib/src/mutation/legacy_mutation_migration.dart
@@ -1,0 +1,247 @@
+import 'package:fasq/src/mutation/durable_mutation_queue.dart';
+import 'package:fasq/src/mutation/offline_queue.dart';
+import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
+
+/// Runtime registration used to translate one legacy mutation type.
+abstract interface class LegacyMutationRegistration {
+  /// Legacy type stored in [OfflineMutationNode.mutationType].
+  String get mutationType;
+
+  /// Stable key used by the durable mutation registry.
+  MutationKey get key;
+
+  /// Registers the existing immediate executor with [queue].
+  void register(DurableMutationQueue queue);
+
+  /// Translates and enqueues [node] into [queue].
+  Future<DurableEnqueueAcknowledgement> enqueue(
+    DurableMutationQueue queue,
+    OfflineMutationNode node,
+  );
+}
+
+/// Typed legacy registration backed by the same executor used online.
+class TypedLegacyMutationRegistration<TData, TVariables>
+    implements LegacyMutationRegistration {
+  /// Creates a typed legacy-to-durable registration.
+  const TypedLegacyMutationRegistration({
+    required this.mutationType,
+    required this.key,
+    required this.codec,
+    required this.mutationFn,
+    this.authPolicy = AuthPolicy.none,
+    this.authScope,
+    this.authScopeResolver,
+    this.maxAge = const Duration(days: 3650),
+    this.resultEncoder,
+  });
+
+  @override
+  final String mutationType;
+
+  @override
+  final MutationKey key;
+
+  /// Codec for the legacy node variables.
+  final MutationCodec<TVariables> codec;
+
+  /// Existing online mutation executor.
+  final Future<TData> Function(TVariables variables) mutationFn;
+
+  /// Authentication policy applied to imported operations.
+  final AuthPolicy authPolicy;
+
+  /// Non-secret identity used when imported work requires auth.
+  final AuthScope? authScope;
+
+  /// Resolves auth scope for each imported legacy node.
+  final AuthScope? Function(OfflineMutationNode node)? authScopeResolver;
+
+  /// Maximum age retained for imported work; override for app-specific policy.
+  final Duration maxAge;
+
+  /// Optional JSON-safe result encoder for replay history.
+  final Object? Function(TData data)? resultEncoder;
+
+  @override
+  void register(DurableMutationQueue queue) {
+    queue.register<TData, TVariables>(
+      key: key,
+      codec: codec,
+      mutationFn: mutationFn,
+      authPolicy: authPolicy,
+      resultEncoder: resultEncoder,
+    );
+  }
+
+  @override
+  Future<DurableEnqueueAcknowledgement> enqueue(
+    DurableMutationQueue queue,
+    OfflineMutationNode node,
+  ) async {
+    final variables = codec.decode(node.variables);
+    final state = switch (node.status) {
+      OfflineMutationStatus.pending => MutationOperationState.pending,
+      OfflineMutationStatus.retryScheduled =>
+        MutationOperationState.retryScheduled,
+      _ => throw LegacyMutationMigrationException(
+        node.id,
+        'Only pending or retryScheduled nodes can be migrated safely',
+      ),
+    };
+    final resolvedAuthScope = authScopeResolver?.call(node) ?? authScope;
+    if ((authPolicy == AuthPolicy.required) != (resolvedAuthScope != null)) {
+      throw LegacyMutationMigrationException(
+        node.id,
+        'Required auth scope is not available for legacy work',
+      );
+    }
+
+    return queue.enqueue<TVariables>(
+      key: key,
+      variables: variables,
+      operationId: OperationId(node.id),
+      idempotencyKey: IdempotencyKey(node.idempotencyKey),
+      lineageId: LineageId('legacy:${node.id}'),
+      authScope: resolvedAuthScope,
+      createdAt: node.createdAt,
+      priority: node.priority,
+      dependencies: node.dependsOnIds
+          .map(
+            (id) => MutationDependency(parentOperationId: OperationId(id)),
+          )
+          .toList(growable: false),
+      state: state,
+      attemptCount: node.attempts,
+      maxAttempts: node.maxRetries,
+      maxAge: maxAge,
+      nextRunAt: node.nextRunAt,
+    );
+  }
+}
+
+/// Imports active legacy queue nodes into a durable queue.
+class LegacyMutationQueueMigrator {
+  /// Creates a migrator from legacy mutation types to stable registrations.
+  const LegacyMutationQueueMigrator({required this.registrations});
+
+  /// Registration keyed by [OfflineMutationNode.mutationType].
+  final Map<String, LegacyMutationRegistration> registrations;
+
+  /// Migrates active legacy nodes after durable enqueue acknowledgement.
+  ///
+  /// Source nodes are removed only after their durable operation commits. The
+  /// destination remains open for the caller to replay or continue enqueueing.
+  Future<LegacyMutationMigrationReport> migrate({
+    required OfflineQueueManager source,
+    required DurableMutationQueue destination,
+    bool removeSourceAfterCommit = true,
+  }) async {
+    await source.load();
+    final nodes = List<OfflineMutationNode>.from(source.entries);
+    final missing = nodes
+        .where((node) => !registrations.containsKey(node.mutationType))
+        .map((node) => node.mutationType)
+        .toSet();
+    if (missing.isNotEmpty) {
+      throw LegacyMutationMigrationException(
+        missing.first,
+        'No stable migration registration exists for legacy mutation type',
+      );
+    }
+
+    await destination.open();
+    final sourceIds = nodes.map((node) => node.id).toSet();
+    for (final node in nodes) {
+      if (node.status != OfflineMutationStatus.pending &&
+          node.status != OfflineMutationStatus.retryScheduled) {
+        throw LegacyMutationMigrationException(
+          node.id,
+          'Legacy status ${node.status.name} has ambiguous execution outcome',
+        );
+      }
+      for (final parentId in node.dependsOnIds) {
+        if (!sourceIds.contains(parentId) &&
+            !destination.hasRetainedOperation(OperationId(parentId))) {
+          throw LegacyMutationMigrationException(
+            node.id,
+            'Dependency $parentId is not present in legacy or durable storage',
+          );
+        }
+      }
+    }
+
+    for (final node in nodes) {
+      final registration = registrations[node.mutationType]!;
+      if (!destination.hasRegistration(registration.key)) {
+        registration.register(destination);
+      }
+    }
+
+    final migrated = <OperationId>[];
+    final alreadyPresent = <OperationId>[];
+    for (final node in nodes) {
+      final registration = registrations[node.mutationType]!;
+      final operationId = OperationId(node.id);
+      if (destination.hasRetainedOperation(operationId)) {
+        alreadyPresent.add(operationId);
+        if (removeSourceAfterCommit) await source.remove(node.id);
+        continue;
+      }
+      try {
+        final acknowledgement = await registration.enqueue(destination, node);
+        migrated.add(acknowledgement.operationId);
+      } on LegacyMutationMigrationException {
+        rethrow;
+      } on Object catch (error, stackTrace) {
+        Error.throwWithStackTrace(
+          LegacyMutationMigrationException(node.id, error.toString()),
+          stackTrace,
+        );
+      }
+      if (removeSourceAfterCommit) await source.remove(node.id);
+    }
+    return LegacyMutationMigrationReport(
+      migratedOperationIds: migrated,
+      alreadyPresentOperationIds: alreadyPresent,
+      untouchedDeadLetterCount: source.deadLetters.length,
+    );
+  }
+}
+
+/// Result of one legacy queue migration request.
+class LegacyMutationMigrationReport {
+  /// Creates a migration report.
+  LegacyMutationMigrationReport({
+    required List<OperationId> migratedOperationIds,
+    required this.untouchedDeadLetterCount,
+    List<OperationId> alreadyPresentOperationIds = const <OperationId>[],
+  }) : migratedOperationIds = List.unmodifiable(migratedOperationIds),
+       alreadyPresentOperationIds = List.unmodifiable(
+         alreadyPresentOperationIds,
+       );
+
+  /// Durable operation IDs committed by the migration.
+  final List<OperationId> migratedOperationIds;
+
+  /// IDs already retained after a prior durable commit.
+  final List<OperationId> alreadyPresentOperationIds;
+
+  /// Legacy dead letters intentionally left in their original manager.
+  final int untouchedDeadLetterCount;
+
+  /// Number of legacy nodes committed to the durable queue.
+  int get migratedCount => migratedOperationIds.length;
+}
+
+/// Safe error identifying a legacy node that could not be migrated.
+class LegacyMutationMigrationException extends MutationContractException {
+  /// Creates a migration failure for [legacyNodeId].
+  LegacyMutationMigrationException(String legacyNodeId, String reason)
+    : super(
+        'Legacy mutation node $legacyNodeId could not be migrated: $reason',
+      );
+}

--- a/packages/fasq/lib/src/mutation/legacy_mutation_migration.dart
+++ b/packages/fasq/lib/src/mutation/legacy_mutation_migration.dart
@@ -16,6 +16,9 @@ abstract interface class LegacyMutationRegistration {
   /// Registers the existing immediate executor with [queue].
   void register(DurableMutationQueue queue);
 
+  /// Validates a legacy node without writing to the durable queue.
+  void validate(OfflineMutationNode node);
+
   /// Translates and enqueues [node] into [queue].
   Future<DurableEnqueueAcknowledgement> enqueue(
     DurableMutationQueue queue,
@@ -78,10 +81,40 @@ class TypedLegacyMutationRegistration<TData, TVariables>
   }
 
   @override
+  void validate(OfflineMutationNode node) {
+    try {
+      codec.decode(node.variables);
+      _resolveAuthScope(node);
+      if (maxAge <= Duration.zero) {
+        throw const InvalidMutationPayloadException(
+          'Legacy mutation retention policy is invalid',
+        );
+      }
+      OperationId(node.id);
+      IdempotencyKey(node.idempotencyKey);
+      LineageId('legacy:${node.id}');
+      for (final parentId in node.dependsOnIds) {
+        OperationId(parentId);
+      }
+    } on LegacyMutationMigrationException {
+      rethrow;
+    } on Object catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        LegacyMutationMigrationException(
+          node.id,
+          'Legacy mutation payload or identity is invalid',
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  @override
   Future<DurableEnqueueAcknowledgement> enqueue(
     DurableMutationQueue queue,
     OfflineMutationNode node,
   ) async {
+    validate(node);
     final variables = codec.decode(node.variables);
     final state = switch (node.status) {
       OfflineMutationStatus.pending => MutationOperationState.pending,
@@ -92,13 +125,7 @@ class TypedLegacyMutationRegistration<TData, TVariables>
         'Only pending or retryScheduled nodes can be migrated safely',
       ),
     };
-    final resolvedAuthScope = authScopeResolver?.call(node) ?? authScope;
-    if ((authPolicy == AuthPolicy.required) != (resolvedAuthScope != null)) {
-      throw LegacyMutationMigrationException(
-        node.id,
-        'Required auth scope is not available for legacy work',
-      );
-    }
+    final resolvedAuthScope = _resolveAuthScope(node);
 
     return queue.enqueue<TVariables>(
       key: key,
@@ -120,6 +147,17 @@ class TypedLegacyMutationRegistration<TData, TVariables>
       maxAge: maxAge,
       nextRunAt: node.nextRunAt,
     );
+  }
+
+  AuthScope? _resolveAuthScope(OfflineMutationNode node) {
+    final resolved = authScopeResolver?.call(node) ?? authScope;
+    if ((authPolicy == AuthPolicy.required) != (resolved != null)) {
+      throw LegacyMutationMigrationException(
+        node.id,
+        'Required auth scope is not available for legacy work',
+      );
+    }
+    return resolved;
   }
 }
 
@@ -155,6 +193,12 @@ class LegacyMutationQueueMigrator {
 
     await destination.open();
     final sourceIds = nodes.map((node) => node.id).toSet();
+    if (sourceIds.length != nodes.length) {
+      throw LegacyMutationMigrationException(
+        'unknown',
+        'Legacy queue contains duplicate operation identities',
+      );
+    }
     for (final node in nodes) {
       if (node.status != OfflineMutationStatus.pending &&
           node.status != OfflineMutationStatus.retryScheduled) {
@@ -164,14 +208,28 @@ class LegacyMutationQueueMigrator {
         );
       }
       for (final parentId in node.dependsOnIds) {
+        final parentOperationId = _parseOperationId(node.id, parentId);
         if (!sourceIds.contains(parentId) &&
-            !destination.hasRetainedOperation(OperationId(parentId))) {
+            !destination.hasRetainedOperation(parentOperationId)) {
           throw LegacyMutationMigrationException(
             node.id,
             'Dependency $parentId is not present in legacy or durable storage',
           );
         }
       }
+    }
+
+    for (final node in nodes) {
+      final operationId = _parseOperationId(node.id, node.id);
+      final idempotencyKey = _parseIdempotencyKey(node.id, node.idempotencyKey);
+      if (destination.hasRetainedOperation(operationId)) continue;
+      if (destination.hasRetainedIdempotencyKey(idempotencyKey)) {
+        throw LegacyMutationMigrationException(
+          node.id,
+          'Legacy idempotency identity is already retained durably',
+        );
+      }
+      registrations[node.mutationType]!.validate(node);
     }
 
     for (final node in nodes) {
@@ -185,7 +243,7 @@ class LegacyMutationQueueMigrator {
     final alreadyPresent = <OperationId>[];
     for (final node in nodes) {
       final registration = registrations[node.mutationType]!;
-      final operationId = OperationId(node.id);
+      final operationId = _parseOperationId(node.id, node.id);
       if (destination.hasRetainedOperation(operationId)) {
         alreadyPresent.add(operationId);
         if (removeSourceAfterCommit) await source.remove(node.id);
@@ -196,9 +254,12 @@ class LegacyMutationQueueMigrator {
         migrated.add(acknowledgement.operationId);
       } on LegacyMutationMigrationException {
         rethrow;
-      } on Object catch (error, stackTrace) {
+      } on Object catch (_, stackTrace) {
         Error.throwWithStackTrace(
-          LegacyMutationMigrationException(node.id, error.toString()),
+          LegacyMutationMigrationException(
+            node.id,
+            'Legacy mutation could not be durably imported',
+          ),
           stackTrace,
         );
       }
@@ -209,6 +270,34 @@ class LegacyMutationQueueMigrator {
       alreadyPresentOperationIds: alreadyPresent,
       untouchedDeadLetterCount: source.deadLetters.length,
     );
+  }
+
+  OperationId _parseOperationId(String nodeId, String value) {
+    try {
+      return OperationId(value);
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        LegacyMutationMigrationException(
+          nodeId,
+          'Legacy operation identity is invalid',
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  IdempotencyKey _parseIdempotencyKey(String nodeId, String value) {
+    try {
+      return IdempotencyKey(value);
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        LegacyMutationMigrationException(
+          nodeId,
+          'Legacy idempotency identity is invalid',
+        ),
+        stackTrace,
+      );
+    }
   }
 }
 

--- a/packages/fasq/lib/src/mutation/mutation.dart
+++ b/packages/fasq/lib/src/mutation/mutation.dart
@@ -16,12 +16,14 @@ class Mutation<T, TVariables> {
     _controller = StreamController<MutationState<T>>.broadcast();
     options?.validateDurableConfiguration();
     final durableQueue = options?.durableQueue;
-    if (durableQueue != null) {
+    if (durableQueue != null &&
+        !durableQueue.queue.hasRegistration(durableQueue.mutationKey)) {
       durableQueue.queue.register<T, TVariables>(
         key: durableQueue.mutationKey,
         codec: durableQueue.codec,
         mutationFn: mutationFn,
         authPolicy: durableQueue.authPolicy,
+        resultEncoder: options?.resultEncoder,
       );
     }
   }

--- a/packages/fasq/lib/src/mutation/mutation.dart
+++ b/packages/fasq/lib/src/mutation/mutation.dart
@@ -5,7 +5,6 @@ import 'package:fasq/src/mutation/mutation_options.dart';
 import 'package:fasq/src/mutation/mutation_snapshot.dart';
 import 'package:fasq/src/mutation/mutation_state.dart';
 import 'package:fasq/src/mutation/network_status.dart';
-import 'package:fasq/src/mutation/offline_queue.dart';
 
 /// Executes and tracks a mutation with optional offline queueing.
 class Mutation<T, TVariables> {
@@ -15,6 +14,16 @@ class Mutation<T, TVariables> {
     this.options,
   }) {
     _controller = StreamController<MutationState<T>>.broadcast();
+    options?.validateDurableConfiguration();
+    final durableQueue = options?.durableQueue;
+    if (durableQueue != null) {
+      durableQueue.queue.register<T, TVariables>(
+        key: durableQueue.mutationKey,
+        codec: durableQueue.codec,
+        mutationFn: mutationFn,
+        authPolicy: durableQueue.authPolicy,
+      );
+    }
   }
 
   /// Function that performs the mutation work.
@@ -50,19 +59,31 @@ class Mutation<T, TVariables> {
     final shouldQueue = isOffline && (options?.queueWhenOffline ?? false);
 
     if (shouldQueue) {
-      final queueManager = OfflineQueueManager.instance();
-      final mutationType = _getMutationType();
-
-      await queueManager.enqueue(
-        'mutation_${DateTime.now().millisecondsSinceEpoch}',
-        mutationType,
-        variables,
-        priority: options?.priority ?? 0,
-      );
-
-      _updateState(const MutationState.queued());
-      options?.onQueued?.call(variables);
-      return;
+      final durableQueue = options?.durableQueue;
+      if (durableQueue == null) {
+        throw StateError(
+          'queueWhenOffline requires durable queue configuration',
+        );
+      }
+      try {
+        await durableQueue.queue.open();
+        await durableQueue.queue.enqueue(
+          key: durableQueue.mutationKey,
+          variables: variables,
+          authScope: durableQueue.authScope,
+          priority: options?.priority ?? 0,
+          maxAttempts: options?.maxRetries ?? 5,
+        );
+        _updateState(const MutationState.queued());
+        options?.onQueued?.call(variables);
+        return;
+      } on Object catch (error, stackTrace) {
+        if (!_isDisposed) {
+          _updateState(MutationState.error(error, stackTrace));
+          options?.onError?.call(error);
+        }
+        rethrow;
+      }
     }
 
     _lastVariables = variables;
@@ -102,12 +123,6 @@ class Mutation<T, TVariables> {
         }
       }
     }
-  }
-
-  String _getMutationType() {
-    // Generate a unique mutation type based on the mutation function
-    // In a real app, you'd want to register these explicitly
-    return 'mutation_${mutationFn.hashCode}';
   }
 
   /// Resets this mutation to the idle state.

--- a/packages/fasq/lib/src/mutation/mutation_options.dart
+++ b/packages/fasq/lib/src/mutation/mutation_options.dart
@@ -1,4 +1,39 @@
+import 'package:fasq/src/mutation/durable_mutation_queue.dart';
 import 'package:fasq/src/mutation/mutation_meta.dart';
+import 'package:fasq/src/mutation/sync_engine/mutation_contracts.dart';
+import 'package:meta/meta.dart';
+
+/// Configuration required to persist and replay a mutation after restart.
+///
+/// The key identifies the logical mutation definition. The codec keeps the
+/// queued variables JSON-safe and reconstructs their typed value before the
+/// registered mutation executor runs.
+@immutable
+class DurableMutationQueueOptions<TVariables> {
+  /// Creates durable queue configuration for a mutation.
+  const DurableMutationQueueOptions({
+    required this.queue,
+    required this.mutationKey,
+    required this.codec,
+    this.authPolicy = AuthPolicy.none,
+    this.authScope,
+  });
+
+  /// Durable queue used to persist and replay this mutation.
+  final DurableMutationQueue queue;
+
+  /// Stable, versioned identity for the logical mutation definition.
+  final MutationKey mutationKey;
+
+  /// Typed codec for the persisted mutation variables.
+  final MutationCodec<TVariables> codec;
+
+  /// Authentication requirement captured with each queued operation.
+  final AuthPolicy authPolicy;
+
+  /// Exact non-secret identity captured with each authenticated operation.
+  final AuthScope? authScope;
+}
 
 /// Configuration options for mutation behavior and lifecycle callbacks.
 class MutationOptions<T, TVariables> {
@@ -8,11 +43,15 @@ class MutationOptions<T, TVariables> {
     this.onError,
     this.onMutate,
     this.queueWhenOffline = false,
+    this.durableQueue,
     this.maxRetries,
     this.onQueued,
     this.priority = 0,
     this.meta,
-  });
+  }) : assert(
+         !queueWhenOffline || durableQueue != null,
+         'queueWhenOffline requires durableQueue configuration',
+       );
 
   /// Called when the mutation succeeds.
   final void Function(T data)? onSuccess;
@@ -25,6 +64,33 @@ class MutationOptions<T, TVariables> {
 
   /// Whether to queue this mutation when offline.
   final bool queueWhenOffline;
+
+  /// Stable identity, typed codec, and auth policy for durable queueing.
+  ///
+  /// This must be provided when [queueWhenOffline] is true. It is ignored for
+  /// online-only mutations and does not change immediate execution behavior.
+  final DurableMutationQueueOptions<TVariables>? durableQueue;
+
+  /// Stable logical identity for this mutation, if durable queueing is enabled.
+  MutationKey? get mutationKey => durableQueue?.mutationKey;
+
+  /// Typed variable codec, if durable queueing is enabled.
+  MutationCodec<TVariables>? get codec => durableQueue?.codec;
+
+  /// Authentication policy for queued operations.
+  AuthPolicy get authPolicy => durableQueue?.authPolicy ?? AuthPolicy.none;
+
+  /// Validates the durable queue contract at a runtime integration boundary.
+  ///
+  /// The constructor assertion catches invalid configuration in debug builds;
+  /// this method keeps the same rejection behavior when assertions are off.
+  void validateDurableConfiguration() {
+    if (queueWhenOffline && durableQueue == null) {
+      throw ArgumentError(
+        'queueWhenOffline requires durableQueue configuration',
+      );
+    }
+  }
 
   /// Maximum retry attempts for failed mutations.
   final int? maxRetries;

--- a/packages/fasq/lib/src/mutation/mutation_options.dart
+++ b/packages/fasq/lib/src/mutation/mutation_options.dart
@@ -44,6 +44,7 @@ class MutationOptions<T, TVariables> {
     this.onMutate,
     this.queueWhenOffline = false,
     this.durableQueue,
+    this.resultEncoder,
     this.maxRetries,
     this.onQueued,
     this.priority = 0,
@@ -70,6 +71,9 @@ class MutationOptions<T, TVariables> {
   /// This must be provided when [queueWhenOffline] is true. It is ignored for
   /// online-only mutations and does not change immediate execution behavior.
   final DurableMutationQueueOptions<TVariables>? durableQueue;
+
+  /// Encodes mutation results for durable replay history.
+  final Object? Function(T data)? resultEncoder;
 
   /// Stable logical identity for this mutation, if durable queueing is enabled.
   MutationKey? get mutationKey => durableQueue?.mutationKey;

--- a/packages/fasq/test/mutation/durable_mutation_queue_test.dart
+++ b/packages/fasq/test/mutation/durable_mutation_queue_test.dart
@@ -1,0 +1,289 @@
+// Registration calls intentionally use one receiver per test; the repository
+// enables a conflicting cascade lint for this form.
+// ignore_for_file: cascade_invocations
+
+import 'package:fasq/src/mutation/durable_mutation_queue.dart';
+import 'package:fasq/src/mutation/sync_engine/codecs/mutation_codec.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_identity.dart';
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
+import 'package:fasq/src/mutation/sync_engine/store/durable_outbox.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_errors.dart';
+import 'package:fasq/src/mutation/sync_engine/store/outbox_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final key = MutationKey(namespace: 'todos', name: 'create');
+
+  test('acknowledges enqueue only after durable transaction commits', () async {
+    final store = _MemoryOutboxStore();
+    final queue = DurableMutationQueue(
+      store: store,
+      now: () => DateTime.utc(2026, 8, 20),
+      idGenerator: _idGenerator(<String>[
+        'generated-operation',
+        'generated-idempotency',
+        'generated-lineage',
+      ]),
+    );
+    queue.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (variables) async => variables,
+    );
+
+    await queue.open();
+    final acknowledgement = await queue.enqueue(
+      key: key,
+      variables: <String, Object?>{'title': 'offline'},
+    );
+
+    expect(store.transactionCount, 1);
+    expect(acknowledgement.operationId.value, 'generated-operation');
+    expect(acknowledgement.idempotencyKey.value, 'generated-idempotency');
+    expect(acknowledgement.lineageId.value, 'generated-lineage');
+    expect(queue.snapshot.active.single, acknowledgement.operation);
+    expect(queue.generation, 1);
+    await queue.close();
+  });
+
+  test(
+    'rejects unknown registrations and non-JSON encoded variables',
+    () async {
+      final store = _MemoryOutboxStore();
+      final queue = DurableMutationQueue(store: store);
+      await queue.open();
+
+      expect(
+        () => queue.enqueue(key: key, variables: <String, Object?>{}),
+        throwsA(isA<UnknownMutationKeyException>()),
+      );
+
+      final invalidKey = MutationKey(namespace: 'todos', name: 'invalid');
+      queue.register<Object?, Object?>(
+        key: invalidKey,
+        codec: JsonMutationCodec<Object?>(
+          encoder: (_) => DateTime.utc(2026),
+          decoder: (payload) => payload,
+        ),
+        mutationFn: (_) async => null,
+      );
+      expect(
+        () => queue.enqueue(key: invalidKey, variables: 'value'),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
+      expect(store.transactionCount, 0);
+      await queue.close();
+    },
+  );
+
+  test(
+    'reopens and replays through the explicitly registered mutationFn',
+    () async {
+      final store = _MemoryOutboxStore();
+      final operationId = OperationId('operation-1');
+      final idempotencyKey = IdempotencyKey('idempotency-1');
+      final lineageId = LineageId('lineage-1');
+      var calls = 0;
+      final firstQueue = DurableMutationQueue(store: store);
+      firstQueue.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async => <String, Object?>{
+          'created': variables['title'],
+        },
+      );
+      await firstQueue.open();
+      final acknowledgement = await firstQueue.enqueue(
+        key: key,
+        variables: <String, Object?>{'title': 'offline'},
+        operationId: operationId,
+        idempotencyKey: idempotencyKey,
+        lineageId: lineageId,
+      );
+      await firstQueue.close();
+
+      final secondQueue = DurableMutationQueue(store: store);
+      secondQueue.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async {
+          calls++;
+          return <String, Object?>{'created': variables['title']};
+        },
+      );
+      await secondQueue.open();
+      final report = await secondQueue.replay();
+
+      expect(acknowledgement.operationId, operationId);
+      expect(report.executedOperationIds, <OperationId>[operationId]);
+      expect(calls, 1);
+      expect(secondQueue.snapshot.active, isEmpty);
+      expect(secondQueue.snapshot.history.single.operationId, operationId);
+      expect(
+        secondQueue.snapshot.history.single.state,
+        MutationOperationState.succeeded,
+      );
+      await secondQueue.close();
+    },
+  );
+
+  test(
+    'preserves typed storage failures and translates unknown backend errors',
+    () async {
+      final typedStore = _MemoryOutboxStore(
+        failure: const OutboxCapacityExceededException(),
+      );
+      final typedQueue = DurableMutationQueue(store: typedStore);
+      typedQueue.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async => variables,
+      );
+      await typedQueue.open();
+      expect(
+        () => typedQueue.enqueue(key: key, variables: <String, Object?>{}),
+        throwsA(isA<OutboxCapacityExceededException>()),
+      );
+      await typedQueue.close();
+
+      final unknownStore = _MemoryOutboxStore(failure: StateError('disk down'));
+      final unknownQueue = DurableMutationQueue(store: unknownStore);
+      unknownQueue.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async => variables,
+      );
+      await unknownQueue.open();
+      expect(
+        () => unknownQueue.enqueue(key: key, variables: <String, Object?>{}),
+        throwsA(isA<DurableMutationQueueStorageException>()),
+      );
+      await unknownQueue.close();
+    },
+  );
+
+  test('rejects retained duplicate operation identities', () async {
+    final store = _MemoryOutboxStore();
+    final queue = DurableMutationQueue(store: store);
+    queue.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (variables) async => variables,
+    );
+    await queue.open();
+    final operationId = OperationId('duplicate');
+    await queue.enqueue(
+      key: key,
+      variables: <String, Object?>{},
+      operationId: operationId,
+      idempotencyKey: IdempotencyKey('first'),
+      lineageId: LineageId('first'),
+    );
+
+    expect(
+      () => queue.enqueue(
+        key: key,
+        variables: <String, Object?>{},
+        operationId: operationId,
+        idempotencyKey: IdempotencyKey('second'),
+        lineageId: LineageId('second'),
+      ),
+      throwsA(isA<DuplicateMutationOperationException>()),
+    );
+    await queue.close();
+  });
+
+  test(
+    'keeps processQueue as an explicit replay compatibility alias',
+    () async {
+      final store = _MemoryOutboxStore();
+      var calls = 0;
+      final queue = DurableMutationQueue(store: store);
+      queue.register<Map<String, Object?>, Map<String, Object?>>(
+        key: key,
+        codec: _mapCodec,
+        mutationFn: (variables) async {
+          calls++;
+          return variables;
+        },
+      );
+      await queue.open();
+      final operation = await queue.enqueue(
+        key: key,
+        variables: <String, Object?>{'title': 'compat'},
+      );
+
+      final report = await queue.processQueue();
+
+      expect(report.executedOperationIds, <OperationId>[operation.operationId]);
+      expect(calls, 1);
+      expect(queue.snapshot.active, isEmpty);
+      await queue.close();
+    },
+  );
+}
+
+final _mapCodec = JsonMutationCodec<Map<String, Object?>>(
+  encoder: (value) => value,
+  decoder: (payload) {
+    if (payload is! Map<Object?, Object?> ||
+        payload.keys.any((key) => key is! String)) {
+      throw const InvalidMutationPayloadException('Expected a JSON object');
+    }
+    return Map<String, Object?>.fromEntries(
+      payload.entries.map(
+        (entry) => MapEntry(entry.key! as String, entry.value),
+      ),
+    );
+  },
+);
+
+String Function() _idGenerator(List<String> ids) =>
+    () => ids.removeAt(0);
+
+class _MemoryOutboxStore implements DurableOutboxStore {
+  _MemoryOutboxStore({this.failure});
+
+  final Object? failure;
+  OutboxSnapshot _snapshot = OutboxSnapshot();
+  int _generation = 0;
+  bool _isOpen = false;
+  int transactionCount = 0;
+
+  @override
+  Future<OutboxSnapshot> open() async {
+    _isOpen = true;
+    return _snapshot;
+  }
+
+  @override
+  OutboxSnapshot get snapshot => _snapshot;
+
+  @override
+  int get generation => _generation;
+
+  @override
+  Future<OutboxSnapshot> transact(
+    DurableOutboxTransaction transaction, {
+    int? expectedGeneration,
+  }) async {
+    if (!_isOpen) throw StateError('store is closed');
+    if (expectedGeneration != null && expectedGeneration != _generation) {
+      throw const OutboxGenerationConflictException();
+    }
+    final error = failure;
+    if (error != null) {
+      Error.throwWithStackTrace(error, StackTrace.current);
+    }
+    _snapshot = transaction(_snapshot);
+    _generation++;
+    transactionCount++;
+    return _snapshot;
+  }
+
+  @override
+  Future<void> close() async {
+    _isOpen = false;
+  }
+}

--- a/packages/fasq/test/mutation/durable_mutation_queue_test.dart
+++ b/packages/fasq/test/mutation/durable_mutation_queue_test.dart
@@ -194,6 +194,27 @@ void main() {
     await queue.close();
   });
 
+  test('rejects non-replayable enqueue states', () async {
+    final queue = DurableMutationQueue(store: _MemoryOutboxStore());
+    queue.register<Map<String, Object?>, Map<String, Object?>>(
+      key: key,
+      codec: _mapCodec,
+      mutationFn: (variables) async => variables,
+    );
+    await queue.open();
+
+    expect(
+      () => queue.enqueue(
+        key: key,
+        variables: <String, Object?>{},
+        state: MutationOperationState.succeeded,
+      ),
+      throwsA(isA<InvalidMutationEnqueueStateException>()),
+    );
+    expect(queue.snapshot.active, isEmpty);
+    await queue.close();
+  });
+
   test(
     'keeps processQueue as an explicit replay compatibility alias',
     () async {

--- a/packages/fasq/test/mutation/legacy_mutation_migration_test.dart
+++ b/packages/fasq/test/mutation/legacy_mutation_migration_test.dart
@@ -1,0 +1,186 @@
+import 'package:fasq/fasq.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late OfflineQueueManager legacyQueue;
+
+  setUp(() async {
+    legacyQueue = OfflineQueueManager.instance();
+    await legacyQueue.resetForTesting();
+  });
+
+  tearDown(OfflineQueueManager.resetForTestingStatic);
+
+  test('moves legacy nodes into durable storage and replays them', () async {
+    final key = MutationKey(namespace: 'legacy', name: 'create');
+    var calls = 0;
+    final durableQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+    final migrator = LegacyMutationQueueMigrator(
+      registrations: {
+        'legacy-create':
+            TypedLegacyMutationRegistration<String, Map<String, Object?>>(
+              mutationType: 'legacy-create',
+              key: key,
+              codec: _mapCodec,
+              mutationFn: (variables) async {
+                calls++;
+                return 'created:${variables['title']}';
+              },
+            ),
+      },
+    );
+
+    await legacyQueue.enqueue(
+      'legacy-key',
+      'legacy-create',
+      <String, Object?>{'title': 'offline'},
+      idempotencyKey: 'legacy-idempotency',
+      maxRetries: 4,
+    );
+    final legacyNode = legacyQueue.entries.single;
+
+    final report = await migrator.migrate(
+      source: legacyQueue,
+      destination: durableQueue,
+      removeSourceAfterCommit: false,
+    );
+
+    expect(report.migratedCount, 1);
+    expect(report.migratedOperationIds.single.value, legacyNode.id);
+    expect(legacyQueue.entries, hasLength(1));
+    expect(
+      durableQueue.snapshot.active.single.operationId.value,
+      legacyNode.id,
+    );
+    expect(
+      durableQueue.snapshot.active.single.idempotencyKey.value,
+      'legacy-idempotency',
+    );
+    expect(durableQueue.snapshot.active.single.mutationKey, key);
+
+    final rerun = await migrator.migrate(
+      source: legacyQueue,
+      destination: durableQueue,
+    );
+
+    expect(rerun.migratedCount, 0);
+    expect(rerun.alreadyPresentOperationIds.single.value, legacyNode.id);
+    expect(legacyQueue.entries, isEmpty);
+
+    final replay = await durableQueue.replay();
+
+    expect(replay.didExecute, isTrue);
+    expect(calls, 1);
+    expect(
+      durableQueue.snapshot.history.single.state,
+      MutationOperationState.succeeded,
+    );
+    await durableQueue.close();
+  });
+
+  test(
+    'rejects legacy records without stable migration registration',
+    () async {
+      final durableQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+      await legacyQueue.enqueue('legacy-key', 'unknown-legacy-type', {
+        'value': 1,
+      });
+
+      expect(
+        () => const LegacyMutationQueueMigrator(registrations: {}).migrate(
+          source: legacyQueue,
+          destination: durableQueue,
+        ),
+        throwsA(isA<LegacyMutationMigrationException>()),
+      );
+      expect(legacyQueue.entries, hasLength(1));
+      expect(durableQueue.snapshot.active, isEmpty);
+    },
+  );
+
+  test('rejects missing dependencies before durable writes', () async {
+    final key = MutationKey(namespace: 'legacy', name: 'child');
+    final durableQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+    final migrator = LegacyMutationQueueMigrator(
+      registrations: {
+        'legacy-child':
+            TypedLegacyMutationRegistration<Object?, Map<String, Object?>>(
+              mutationType: 'legacy-child',
+              key: key,
+              codec: _mapCodec,
+              mutationFn: (variables) async => variables,
+            ),
+      },
+    );
+    await legacyQueue.enqueue(
+      'legacy-key',
+      'legacy-child',
+      <String, Object?>{'value': 1},
+      dependsOnIds: const <String>['missing-parent'],
+    );
+
+    expect(
+      () => migrator.migrate(
+        source: legacyQueue,
+        destination: durableQueue,
+      ),
+      throwsA(isA<LegacyMutationMigrationException>()),
+    );
+    expect(legacyQueue.entries, hasLength(1));
+    expect(durableQueue.snapshot.active, isEmpty);
+  });
+}
+
+final _mapCodec = JsonMutationCodec<Map<String, Object?>>(
+  encoder: (value) => value,
+  decoder: (payload) {
+    if (payload is! Map<Object?, Object?> ||
+        payload.keys.any((key) => key is! String)) {
+      throw const InvalidMutationPayloadException('Expected a JSON object');
+    }
+    return Map<String, Object?>.fromEntries(
+      payload.entries.map(
+        (entry) => MapEntry(entry.key! as String, entry.value),
+      ),
+    );
+  },
+);
+
+class _MemoryOutboxStore implements DurableOutboxStore {
+  OutboxSnapshot _snapshot = OutboxSnapshot();
+  int _generation = 0;
+  bool _isOpen = false;
+
+  @override
+  Future<OutboxSnapshot> open() async {
+    _isOpen = true;
+    return _snapshot;
+  }
+
+  @override
+  OutboxSnapshot get snapshot => _snapshot;
+
+  @override
+  int get generation => _generation;
+
+  @override
+  Future<OutboxSnapshot> transact(
+    DurableOutboxTransaction transaction, {
+    int? expectedGeneration,
+  }) async {
+    if (!_isOpen) throw StateError('store is closed');
+    if (expectedGeneration != null && expectedGeneration != _generation) {
+      throw const OutboxGenerationConflictException();
+    }
+    _snapshot = transaction(_snapshot);
+    _generation++;
+    return _snapshot;
+  }
+
+  @override
+  Future<void> close() async {
+    _isOpen = false;
+  }
+}

--- a/packages/fasq/test/mutation/legacy_mutation_migration_test.dart
+++ b/packages/fasq/test/mutation/legacy_mutation_migration_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:fasq/fasq.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -130,6 +132,59 @@ void main() {
     );
     expect(legacyQueue.entries, hasLength(1));
     expect(durableQueue.snapshot.active, isEmpty);
+  });
+
+  test('preflights all nodes before importing any legacy records', () async {
+    final key = MutationKey(namespace: 'legacy', name: 'create');
+    final durableQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+    final migrator = LegacyMutationQueueMigrator(
+      registrations: {
+        'legacy-create':
+            TypedLegacyMutationRegistration<String, Map<String, Object?>>(
+              mutationType: 'legacy-create',
+              key: key,
+              codec: _mapCodec,
+              mutationFn: (variables) async => 'created:${variables['title']}',
+            ),
+      },
+    );
+    final validNode = OfflineMutationNode(
+      id: 'valid-operation',
+      key: 'legacy-key',
+      mutationType: 'legacy-create',
+      variables: <String, Object?>{'title': 'valid'},
+      createdAt: DateTime.utc(2026, 8, 20),
+      idempotencyKey: 'valid-idempotency',
+    );
+    final invalidNode = OfflineMutationNode(
+      id: '',
+      key: 'legacy-key',
+      mutationType: 'legacy-create',
+      variables: <String, Object?>{'title': 'invalid'},
+      createdAt: DateTime.utc(2026, 8, 20),
+      idempotencyKey: 'invalid-idempotency',
+    );
+    final queueFile = await legacyQueue.resolveQueueStorageFileForTesting();
+    await queueFile.writeAsString(
+      jsonEncode({
+        'schemaVersion': 2,
+        'nodes': [validNode.toJson(), invalidNode.toJson()],
+      }),
+      flush: true,
+    );
+    legacyQueue.clearInMemoryOnly();
+
+    expect(
+      () => migrator.migrate(
+        source: legacyQueue,
+        destination: durableQueue,
+      ),
+      throwsA(isA<LegacyMutationMigrationException>()),
+    );
+    expect(durableQueue.snapshot.active, isEmpty);
+
+    await legacyQueue.load();
+    expect(legacyQueue.entries, hasLength(2));
   });
 }
 

--- a/packages/fasq/test/mutation/mutation_offline_test.dart
+++ b/packages/fasq/test/mutation/mutation_offline_test.dart
@@ -161,6 +161,71 @@ void main() {
       },
     );
 
+    test(
+      'replays non-JSON results through the configured result encoder',
+      () async {
+        final replayQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+        final replayMutation = Mutation<DateTime, String>(
+          mutationFn: (data) async => DateTime.utc(2026, 8, data.length),
+          options: MutationOptions(
+            queueWhenOffline: true,
+            resultEncoder: (value) => value.toIso8601String(),
+            durableQueue: DurableMutationQueueOptions(
+              queue: replayQueue,
+              mutationKey: MutationKey(namespace: 'tests', name: 'date-result'),
+              codec: _stringCodec,
+            ),
+          ),
+        );
+
+        NetworkStatus.instance.setOnline(online: false);
+        await replayMutation.mutate('offline');
+        NetworkStatus.instance.setOnline(online: true);
+
+        final report = await replayQueue.replay();
+
+        expect(report.didExecute, isTrue);
+        expect(replayQueue.snapshot.active, isEmpty);
+        expect(
+          replayQueue.snapshot.history.single.resultProjection,
+          '2026-08-07T00:00:00.000Z',
+        );
+
+        replayMutation.dispose();
+        await replayQueue.close();
+      },
+    );
+
+    test('reuses one registration for shared queue and mutation key', () async {
+      final sharedQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+      final options = MutationOptions<String, String>(
+        queueWhenOffline: true,
+        durableQueue: DurableMutationQueueOptions(
+          queue: sharedQueue,
+          mutationKey: MutationKey(namespace: 'tests', name: 'shared'),
+          codec: _stringCodec,
+        ),
+      );
+
+      final first = Mutation<String, String>(
+        mutationFn: (data) async => 'first:$data',
+        options: options,
+      );
+      final second = Mutation<String, String>(
+        mutationFn: (data) async => 'second:$data',
+        options: options,
+      );
+
+      expect(
+        sharedQueue.hasRegistration(options.durableQueue!.mutationKey),
+        isTrue,
+      );
+
+      first.dispose();
+      second.dispose();
+      await sharedQueue.close();
+    });
+
     test('should handle errors when online', () async {
       final errorQueue = DurableMutationQueue(store: _MemoryOutboxStore());
       final errorMutation = Mutation<String, String>(

--- a/packages/fasq/test/mutation/mutation_offline_test.dart
+++ b/packages/fasq/test/mutation/mutation_offline_test.dart
@@ -8,15 +8,22 @@ void main() {
 
   group('Mutation with Offline Queue', () {
     late Mutation<String, String> mutation;
+    late DurableMutationQueue durableQueue;
 
     setUp(() {
+      durableQueue = DurableMutationQueue(store: _MemoryOutboxStore());
       mutation = Mutation<String, String>(
         mutationFn: (data) async {
           await Future<void>.delayed(const Duration(milliseconds: 10));
           return 'Processed: $data';
         },
-        options: const MutationOptions(
+        options: MutationOptions(
           queueWhenOffline: true,
+          durableQueue: DurableMutationQueueOptions(
+            queue: durableQueue,
+            mutationKey: _mutationKey,
+            codec: _stringCodec,
+          ),
         ),
       );
     });
@@ -24,7 +31,7 @@ void main() {
     tearDown(() {
       mutation.dispose();
       NetworkStatus.instance.setOnline(online: true);
-      unawaited(OfflineQueueManager.instance().clear());
+      unawaited(durableQueue.close());
     });
 
     test('should execute immediately when online', () async {
@@ -55,7 +62,7 @@ void main() {
 
       expect(states.length, equals(1));
       expect(states.first.isQueued, isTrue);
-      expect(OfflineQueueManager.instance().length, equals(1));
+      expect(durableQueue.snapshot.active, hasLength(1));
 
       await subscription.cancel();
     });
@@ -79,7 +86,6 @@ void main() {
       expect(states.length, greaterThanOrEqualTo(2));
       expect(states.first.isLoading, isTrue);
       expect(states.last.isSuccess, isTrue);
-      expect(OfflineQueueManager.instance().length, equals(0));
 
       await subscription.cancel();
       mutationNoQueue.dispose();
@@ -87,12 +93,20 @@ void main() {
 
     test('should call onQueued callback when queued', () async {
       String? queuedData;
+      final callbackQueue = DurableMutationQueue(
+        store: _MemoryOutboxStore(),
+      );
       final mutationWithCallback = Mutation<String, String>(
         mutationFn: (data) async {
           return 'Processed: $data';
         },
         options: MutationOptions(
           queueWhenOffline: true,
+          durableQueue: DurableMutationQueueOptions(
+            queue: callbackQueue,
+            mutationKey: _mutationKey,
+            codec: _stringCodec,
+          ),
           onQueued: (data) {
             queuedData = data;
           },
@@ -106,15 +120,60 @@ void main() {
       expect(queuedData, equals('test data'));
 
       mutationWithCallback.dispose();
+      await callbackQueue.close();
     });
 
+    test(
+      'replays queued work through the registered mutation function',
+      () async {
+        var calls = 0;
+        final replayQueue = DurableMutationQueue(store: _MemoryOutboxStore());
+        final replayMutation = Mutation<String, String>(
+          mutationFn: (data) async {
+            calls++;
+            return 'Replayed: $data';
+          },
+          options: MutationOptions(
+            queueWhenOffline: true,
+            durableQueue: DurableMutationQueueOptions(
+              queue: replayQueue,
+              mutationKey: MutationKey(namespace: 'tests', name: 'replay'),
+              codec: _stringCodec,
+            ),
+          ),
+        );
+
+        NetworkStatus.instance.setOnline(online: false);
+        await replayMutation.mutate('after restart');
+        NetworkStatus.instance.setOnline(online: true);
+        final report = await replayQueue.replay();
+
+        expect(calls, 1);
+        expect(report.executedOperationIds, hasLength(1));
+        expect(replayQueue.snapshot.active, isEmpty);
+        expect(
+          replayQueue.snapshot.history.single.state,
+          MutationOperationState.succeeded,
+        );
+
+        replayMutation.dispose();
+        await replayQueue.close();
+      },
+    );
+
     test('should handle errors when online', () async {
+      final errorQueue = DurableMutationQueue(store: _MemoryOutboxStore());
       final errorMutation = Mutation<String, String>(
         mutationFn: (data) async {
           throw Exception('Test error');
         },
-        options: const MutationOptions(
+        options: MutationOptions(
           queueWhenOffline: true,
+          durableQueue: DurableMutationQueueOptions(
+            queue: errorQueue,
+            mutationKey: _mutationKey,
+            codec: _stringCodec,
+          ),
         ),
       );
 
@@ -133,6 +192,7 @@ void main() {
 
       await subscription.cancel();
       errorMutation.dispose();
+      await errorQueue.close();
     });
 
     test('should reset state correctly', () async {
@@ -148,4 +208,53 @@ void main() {
       expect(mutation.state.isIdle, isTrue);
     });
   });
+}
+
+final _mutationKey = MutationKey(namespace: 'tests', name: 'text');
+
+final _stringCodec = JsonMutationCodec<String>(
+  encoder: (value) => value,
+  decoder: (payload) {
+    if (payload is! String) {
+      throw const InvalidMutationPayloadException('Expected a string');
+    }
+    return payload;
+  },
+);
+
+class _MemoryOutboxStore implements DurableOutboxStore {
+  OutboxSnapshot _snapshot = OutboxSnapshot();
+  int _generation = 0;
+  bool _isOpen = false;
+
+  @override
+  Future<OutboxSnapshot> open() async {
+    _isOpen = true;
+    return _snapshot;
+  }
+
+  @override
+  OutboxSnapshot get snapshot => _snapshot;
+
+  @override
+  int get generation => _generation;
+
+  @override
+  Future<OutboxSnapshot> transact(
+    DurableOutboxTransaction transaction, {
+    int? expectedGeneration,
+  }) async {
+    if (!_isOpen) throw StateError('store is closed');
+    if (expectedGeneration != null && expectedGeneration != _generation) {
+      throw const OutboxGenerationConflictException();
+    }
+    _snapshot = transaction(_snapshot);
+    _generation++;
+    return _snapshot;
+  }
+
+  @override
+  Future<void> close() async {
+    _isOpen = false;
+  }
 }

--- a/packages/fasq/test/mutation/mutation_options_contract_test.dart
+++ b/packages/fasq/test/mutation/mutation_options_contract_test.dart
@@ -1,0 +1,102 @@
+import 'package:fasq/fasq.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MutationOptions durable queue contract', () {
+    test('preserves const online-only configuration', () {
+      const options = MutationOptions<String, String>();
+
+      expect(options.queueWhenOffline, isFalse);
+      expect(options.durableQueue, isNull);
+      expect(options.mutationKey, isNull);
+      expect(options.codec, isNull);
+      expect(options.authPolicy, AuthPolicy.none);
+    });
+
+    test('requires durable configuration when queueing is enabled', () {
+      expect(
+        () => MutationOptions<String, String>(queueWhenOffline: true),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('exposes stable key and typed codec through public options', () {
+      final key = MutationKey(namespace: 'todos', name: 'create', version: 2);
+      final codec = JsonMutationCodec<Map<String, Object?>>(
+        encoder: (variables) => variables,
+        decoder: (payload) => Map<String, Object?>.from(payload! as Map),
+      );
+      final options = MutationOptions<String, Map<String, Object?>>(
+        queueWhenOffline: true,
+        durableQueue: DurableMutationQueueOptions(
+          queue: DurableMutationQueue(store: _MemoryOutboxStore()),
+          mutationKey: key,
+          codec: codec,
+          authPolicy: AuthPolicy.required,
+          authScope: AuthScope(
+            principalId: 'user-1',
+            tenantId: 'tenant-1',
+            authRealm: 'primary',
+          ),
+        ),
+      );
+
+      expect(options.mutationKey, same(key));
+      expect(options.mutationKey!.key, 'todos:create:v2');
+      expect(options.codec, same(codec));
+      expect(options.authPolicy, AuthPolicy.required);
+      expect(options.durableQueue!.authScope!.principalId, 'user-1');
+      expect(options.durableQueue, isNotNull);
+      expect(options.validateDurableConfiguration, returnsNormally);
+
+      final payload = options.codec!.encode(<String, Object?>{'title': 'Buy'});
+      expect(options.codec!.decode(payload), <String, Object?>{'title': 'Buy'});
+    });
+
+    test('rejects non-JSON variables through the typed codec', () {
+      final options = MutationOptions<String, DateTime>(
+        queueWhenOffline: true,
+        durableQueue: DurableMutationQueueOptions(
+          queue: DurableMutationQueue(store: _MemoryOutboxStore()),
+          mutationKey: MutationKey(namespace: 'todos', name: 'create'),
+          codec: JsonMutationCodec<DateTime>(
+            encoder: (variables) => variables,
+            decoder: (_) => DateTime.utc(2026),
+          ),
+        ),
+      );
+
+      expect(
+        () => options.codec!.encode(DateTime.utc(2026)),
+        throwsA(isA<InvalidMutationPayloadException>()),
+      );
+    });
+  });
+}
+
+class _MemoryOutboxStore implements DurableOutboxStore {
+  OutboxSnapshot _snapshot = OutboxSnapshot();
+  int _generation = 0;
+
+  @override
+  Future<OutboxSnapshot> open() async => _snapshot;
+
+  @override
+  OutboxSnapshot get snapshot => _snapshot;
+
+  @override
+  int get generation => _generation;
+
+  @override
+  Future<OutboxSnapshot> transact(
+    DurableOutboxTransaction transaction, {
+    int? expectedGeneration,
+  }) async {
+    _snapshot = transaction(_snapshot);
+    _generation++;
+    return _snapshot;
+  }
+
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## Summary

- Add public durable mutation queue configuration with stable `MutationKey`, typed JSON variables, and authentication scope support.
- Route offline mutations through durable enqueue and explicit replay while preserving normal online mutation execution.
- Provide durable acknowledgement, typed persistence failures, queue snapshots, duplicate identity protection, and `processQueue` compatibility.
- Add migration from active legacy mutation records into the durable queue.

## Migration guarantees

- Preserve operation identity, idempotency identity, retry metadata, timestamps, priorities, and dependency relationships.
- Validate registrations, dependencies, authentication scope, and ambiguous legacy execution states before importing records.
- Remove legacy records only after durable persistence succeeds.
- Make interrupted migrations safe to rerun.
- Keep legacy dead-letter records unchanged and report them separately.

## Scope

This change exposes the durable mutation/replay path through the public API without requiring an HTTP client or platform-specific background scheduler.