### PR TITLE
perf: Fix Fasq core performance hotspots

### DIFF
--- a/packages/fasq/lib/src/cache/cache_metrics.dart
+++ b/packages/fasq/lib/src/cache/cache_metrics.dart
@@ -4,41 +4,99 @@ import 'package:fasq/src/observability/performance/throughput_metrics.dart';
 
 class _ThroughputRing {
   _ThroughputRing({required this.bucketCount})
-      : assert(bucketCount > 0, 'bucketCount must be positive'),
-        counts = List<int>.filled(bucketCount, 0),
-        seconds = List<int>.filled(bucketCount, -1);
+    : assert(bucketCount > 0, 'bucketCount must be positive'),
+      counts = List<int>.filled(bucketCount, 0),
+      seconds = List<int>.filled(bucketCount, -1),
+      _tree = _FenwickTree(bucketCount);
 
   final int bucketCount;
   final List<int> counts;
   final List<int> seconds;
+  final _FenwickTree _tree;
+  int? _lastObservedSecond;
 
   void record(DateTime now) {
     final s = now.millisecondsSinceEpoch ~/ 1000;
+    _advance(s);
     final idx = s % bucketCount;
-    if (seconds[idx] != s) {
-      seconds[idx] = s;
-      counts[idx] = 0;
-    }
+    if (seconds[idx] != s) _replace(idx, s, 0);
     counts[idx]++;
+    _tree.add(idx, 1);
   }
 
-  /// O(bucketCount) per call; only counts buckets whose
-  /// second is in [start..end].
-  /// Window is second-granularity ([Duration.inSeconds] truncates).
+  /// Returns a rolling range sum in O(log bucketCount) after lazy expiry.
   int sumLast(Duration window, DateTime now) {
     final end = now.millisecondsSinceEpoch ~/ 1000;
+    _advance(end);
     final windowSecs = window.inSeconds;
     if (windowSecs <= 0) return 0;
     final start = end - windowSecs + 1;
-    var total = 0;
-    for (var i = 0; i < bucketCount; i++) {
-      final sec = seconds[i];
-      if (sec >= start && sec <= end) {
-        total += counts[i];
+    if (windowSecs >= bucketCount) return _tree.total;
+    final firstIndex = start % bucketCount;
+    final lastIndex = end % bucketCount;
+    if (firstIndex <= lastIndex) {
+      return _tree.rangeSum(firstIndex, lastIndex);
+    }
+    return _tree.rangeSum(firstIndex, bucketCount - 1) +
+        _tree.rangeSum(0, lastIndex);
+  }
+
+  void _advance(int second) {
+    final previous = _lastObservedSecond;
+    if (previous == null) {
+      _lastObservedSecond = second;
+      return;
+    }
+    final elapsed = second - previous;
+    if (elapsed <= 0) return;
+    if (elapsed >= bucketCount) {
+      for (var index = 0; index < bucketCount; index++) {
+        _replace(index, second - bucketCount + index + 1, 0);
+      }
+    } else {
+      for (var value = previous + 1; value <= second; value++) {
+        final index = value % bucketCount;
+        if (seconds[index] != value) _replace(index, value, 0);
       }
     }
-    return total;
+    _lastObservedSecond = second;
   }
+
+  void _replace(int index, int second, int count) {
+    final previousCount = counts[index];
+    if (previousCount != count) _tree.add(index, count - previousCount);
+    counts[index] = count;
+    seconds[index] = second;
+  }
+}
+
+class _FenwickTree {
+  _FenwickTree(int length) : _values = List<int>.filled(length + 1, 0);
+
+  final List<int> _values;
+
+  int get total => prefixSum(_values.length - 2);
+
+  void add(int index, int value) {
+    for (
+      var cursor = index + 1;
+      cursor < _values.length;
+      cursor += cursor & -cursor
+    ) {
+      _values[cursor] += value;
+    }
+  }
+
+  int prefixSum(int index) {
+    var result = 0;
+    for (var cursor = index + 1; cursor > 0; cursor -= cursor & -cursor) {
+      result += _values[cursor];
+    }
+    return result;
+  }
+
+  int rangeSum(int start, int end) =>
+      prefixSum(end) - (start == 0 ? 0 : prefixSum(start - 1));
 }
 
 /// Metrics for monitoring cache performance.
@@ -51,7 +109,7 @@ class CacheMetrics {
   /// If `now` is provided, it is used as the UTC clock source for
   /// time-dependent metrics, which is useful for deterministic tests.
   CacheMetrics({DateTime Function()? now})
-      : _nowFn = now ?? (() => DateTime.now().toUtc());
+    : _nowFn = now ?? (() => DateTime.now().toUtc());
 
   final DateTime Function() _nowFn;
 
@@ -286,8 +344,7 @@ class CacheMetrics {
   /// and rates are second-granularity to match
   /// bucket counts. Returns null if no executions in that window.
   ///
-  /// O(bucketCount) per call; fine for debug/inspection — avoid calling
-  /// in hot paths (e.g. every UI frame).
+  /// O(log bucketCount) after lazy expiry; avoid calling in every UI frame.
   ThroughputMetrics? calculateThroughput(
     String queryKey, {
     Duration window = const Duration(minutes: 1),
@@ -512,7 +569,8 @@ class PerformanceSnapshot {
     final raw = json['cacheReport'] ?? json['cacheMetrics'];
     if (raw == null) {
       throw const FormatException(
-          'Missing cacheReport or cacheMetrics in JSON');
+        'Missing cacheReport or cacheMetrics in JSON',
+      );
     }
     final cacheReport = PerformanceReport.fromJson(raw as Map<String, dynamic>);
     final queryMetricsMap = (json['queryMetrics'] as Map<String, dynamic>).map(
@@ -610,7 +668,8 @@ class QueryMetrics {
   /// Throws [FormatException] if the JSON structure is invalid or required
   /// fields are missing.
   factory QueryMetrics.fromJson(Map<String, dynamic> json) {
-    final fetchHistory = (json['fetchHistory'] as List<dynamic>?)
+    final fetchHistory =
+        (json['fetchHistory'] as List<dynamic>?)
             ?.map((d) => Duration(milliseconds: d as int))
             .toList() ??
         [];

--- a/packages/fasq/lib/src/cache/hot_cache.dart
+++ b/packages/fasq/lib/src/cache/hot_cache.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 /// A hot cache entry that tracks access patterns and frequency.
 class _HotEntry<T> {
   _HotEntry({
@@ -31,16 +33,14 @@ class _HotEntry<T> {
 /// Provides O(1) access time for hot items and automatically manages
 /// promotion and eviction based on access patterns.
 class HotCache<T> {
-  // LRU list (most recent at end)
-
   /// Creates a hot cache with the specified maximum size.
   HotCache({this.maxSize = 50})
-      : assert(maxSize > 0, 'maxSize must be greater than 0');
+    : assert(maxSize > 0, 'maxSize must be greater than 0');
 
   /// Maximum number of entries in the hot cache.
   final int maxSize;
-  final Map<String, _HotEntry<T>> _entries = {};
-  final List<String> _accessOrder = [];
+  // LinkedHashMap iteration order is least-recently-used to most-recently-used.
+  final LinkedHashMap<String, _HotEntry<T>> _entries = LinkedHashMap();
 
   /// Get a value from the hot cache
   ///
@@ -51,7 +51,7 @@ class HotCache<T> {
 
     // Update access information
     entry.recordAccess();
-    _updateAccessOrder(key);
+    _touch(key, entry);
 
     return entry.value;
   }
@@ -63,7 +63,7 @@ class HotCache<T> {
     if (_entries.containsKey(key)) {
       // Update existing entry
       _entries[key]!.recordAccess();
-      _updateAccessOrder(key);
+      _touch(key, _entries[key]!);
       return;
     }
 
@@ -79,21 +79,16 @@ class HotCache<T> {
     );
 
     _entries[key] = entry;
-    _accessOrder.add(key);
   }
 
   /// Remove a specific key from the hot cache
   void remove(String key) {
-    final entry = _entries.remove(key);
-    if (entry != null) {
-      _accessOrder.remove(key);
-    }
+    _entries.remove(key);
   }
 
   /// Clear all entries from the hot cache
   void clear() {
     _entries.clear();
-    _accessOrder.clear();
   }
 
   /// Check if the hot cache contains a key
@@ -165,18 +160,17 @@ class HotCache<T> {
     );
   }
 
-  /// Update the access order for a key (move to end of LRU list)
-  void _updateAccessOrder(String key) {
-    _accessOrder
+  /// Moves [key] to the most-recently-used position in O(1) expected time.
+  void _touch(String key, _HotEntry<T> entry) {
+    _entries
       ..remove(key)
-      ..add(key);
+      ..[key] = entry;
   }
 
   /// Evict the least recently used item
   void _evictLeastRecentlyUsed() {
-    if (_accessOrder.isNotEmpty) {
-      final lruKey = _accessOrder.removeAt(0);
-      _entries.remove(lruKey);
+    if (_entries.isNotEmpty) {
+      _entries.remove(_entries.keys.first);
     }
   }
 

--- a/packages/fasq/lib/src/cache/query_cache.dart
+++ b/packages/fasq/lib/src/cache/query_cache.dart
@@ -68,6 +68,7 @@ class QueryCache {
   final bool ownsSecurityResources;
 
   final Map<String, CacheEntry<Object?>> _entries = {};
+  final Map<String, int> _entrySizes = {};
   final Map<String, Future<Object?>> _inFlightRequests = {};
   final Map<String, AsyncLock> _locks = {};
   final CacheMetrics _metrics = CacheMetrics();
@@ -77,6 +78,7 @@ class QueryCache {
   final Map<String, int> _entryVersions = {};
   final Map<String, Type> _keyTypes = {};
   int _versionCounter = 0;
+  int _currentSizeBytes = 0;
   bool _isGcPaused = false;
   final bool _enableMemoryPressure;
 
@@ -94,6 +96,7 @@ class QueryCache {
 
   /// Interval between persistence garbage collection runs, or null to disable.
   static Duration? persistenceGcInterval;
+  static const int _persistedLoadConcurrency = 8;
 
   final CacheDataCodecRegistry _codecRegistry;
   final AsyncLock _encryptionKeyLock = AsyncLock();
@@ -234,7 +237,7 @@ class QueryCache {
       maxAge: maxAge,
     );
 
-    _entries[key] = entry;
+    _replaceEntry(key, entry);
     final version = _nextEntryVersion();
     _entryVersions[key] = version;
     _keyTypes[key] = T;
@@ -266,6 +269,7 @@ class QueryCache {
   void _removeKeyEverywhere(String key, {bool removeFromPersistence = true}) {
     final removed = _entries.remove(key);
     if (removed == null) return;
+    _currentSizeBytes -= _entrySizes.remove(key) ?? removed.estimateSize();
 
     final remove = _inFlightRequests.remove(key);
     if (remove != null) unawaited(remove);
@@ -287,6 +291,7 @@ class QueryCache {
   void _removeInMemoryOnly(String key) {
     final removed = _entries.remove(key);
     if (removed == null) return;
+    _currentSizeBytes -= _entrySizes.remove(key) ?? removed.estimateSize();
     _hotCache.remove(key);
     _entryVersions.remove(key);
     final persistF = _persistOperations.remove(key);
@@ -297,6 +302,8 @@ class QueryCache {
 
   void _clearInMemory() {
     _entries.clear();
+    _entrySizes.clear();
+    _currentSizeBytes = 0;
     _hotCache.clear();
     _inFlightRequests.clear();
     _locks.clear();
@@ -452,11 +459,7 @@ class QueryCache {
 
   /// Current total cache size in bytes.
   int get currentSize {
-    var total = 0;
-    for (final entry in _entries.values) {
-      total += entry.estimateSize();
-    }
-    return total;
+    return _currentSizeBytes;
   }
 
   /// Current number of cache entries.
@@ -532,6 +535,14 @@ class QueryCache {
     _metrics.recordMemoryUsage(currentSize);
   }
 
+  void _replaceEntry(String key, CacheEntry<Object?> entry) {
+    final previousSize = _entrySizes[key] ?? 0;
+    final nextSize = entry.estimateSize();
+    _entries[key] = entry;
+    _entrySizes[key] = nextSize;
+    _currentSizeBytes += nextSize - previousSize;
+  }
+
   void _startGarbageCollection() {
     if (gcInterval == Duration.zero) return;
     _gcTimer = Timer.periodic(gcInterval, (_) {
@@ -566,6 +577,7 @@ class QueryCache {
     for (final key in keysToRemove) {
       final removed = _entries.remove(key);
       if (removed != null) {
+        _currentSizeBytes -= _entrySizes.remove(key) ?? removed.estimateSize();
         _hotCache.remove(key);
         _entryVersions.remove(key);
         _persistOperations.remove(key);
@@ -970,51 +982,58 @@ class QueryCache {
 
       final allKeys = await _persistenceProvider!.getAllKeys();
 
-      for (final key in allKeys) {
-        final encryptedData = await _persistenceProvider!.retrieve(key);
-        if (encryptedData != null) {
-          try {
-            // Decrypt the data
-            final decryptedBytes = await _encryptionProvider!.decrypt(
-              encryptedData,
-              encryptionKey,
-            );
-            final entryJson = utf8.decode(decryptedBytes);
-            final entryMap = jsonDecode(entryJson) as Map<String, dynamic>;
-
-            final entry = _decodePersistedEntry(key, entryMap);
-            if (entry == null) {
-              await _persistenceProvider!.remove(key);
-              continue;
-            }
-
-            if (!entry.isExpired) {
-              _entries[key] = entry;
-              _entryVersions[key] = _nextEntryVersion();
-            } else {
-              await _persistenceProvider!.remove(key);
-            }
-          } on Object catch (e, stackTrace) {
-            try {
-              await _persistenceProvider!.remove(key);
-            } on Object catch (removeError, removeStack) {
-              _logPersistenceError(
-                'Failed to remove corrupted cache entry for key $key',
-                removeError,
-                removeStack,
-              );
-            }
-            _logPersistenceError(
-              'Failed to load persisted cache entry for key $key',
-              e,
-              stackTrace,
-            );
-          }
+      var nextIndex = 0;
+      final workerCount = _persistedLoadConcurrency < allKeys.length
+          ? _persistedLoadConcurrency
+          : allKeys.length;
+      Future<void> loadNext() async {
+        while (true) {
+          final index = nextIndex++;
+          if (index >= allKeys.length) return;
+          await _loadPersistedEntry(allKeys[index], encryptionKey);
         }
       }
+
+      await Future.wait(List.generate(workerCount, (_) => loadNext()));
     } on Object catch (e, stackTrace) {
       _logPersistenceError(
         'Failed to load persisted cache entries',
+        e,
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> _loadPersistedEntry(String key, String encryptionKey) async {
+    final encryptedData = await _persistenceProvider!.retrieve(key);
+    if (encryptedData == null) return;
+
+    try {
+      final decryptedBytes = await _encryptionProvider!.decrypt(
+        encryptedData,
+        encryptionKey,
+      );
+      final entryJson = utf8.decode(decryptedBytes);
+      final entryMap = jsonDecode(entryJson) as Map<String, dynamic>;
+      final entry = _decodePersistedEntry(key, entryMap);
+      if (entry == null || entry.isExpired) {
+        await _persistenceProvider!.remove(key);
+        return;
+      }
+      _replaceEntry(key, entry);
+      _entryVersions[key] = _nextEntryVersion();
+    } on Object catch (e, stackTrace) {
+      try {
+        await _persistenceProvider!.remove(key);
+      } on Object catch (removeError, removeStack) {
+        _logPersistenceError(
+          'Failed to remove corrupted cache entry for key $key',
+          removeError,
+          removeStack,
+        );
+      }
+      _logPersistenceError(
+        'Failed to load persisted cache entry for key $key',
         e,
         stackTrace,
       );

--- a/packages/fasq/lib/src/client/internal/query_client_metrics.dart
+++ b/packages/fasq/lib/src/client/internal/query_client_metrics.dart
@@ -14,13 +14,14 @@ final class QueryClientMetrics {
     required QueryCache cache,
     required Map<String, Query<Object?>> queries,
   }) : _performanceMonitor = PerformanceMonitor(
-          cache: cache,
-          queries: queries,
-        );
+         cache: cache,
+         queries: queries,
+       );
 
   final PerformanceMonitor _performanceMonitor;
   MetricsConfig _metricsConfig = MetricsConfig();
   Timer? _exportTimer;
+  bool _isExporting = false;
 
   /// Returns a snapshot of global performance metrics.
   PerformanceSnapshot getMetrics({
@@ -34,8 +35,9 @@ final class QueryClientMetrics {
     QueryKey queryKey, {
     Duration throughputWindow = const Duration(minutes: 1),
   }) {
-    final snapshot =
-        _performanceMonitor.getSnapshot(throughputWindow: throughputWindow);
+    final snapshot = _performanceMonitor.getSnapshot(
+      throughputWindow: throughputWindow,
+    );
     return snapshot.queryMetrics[queryKey.key];
   }
 
@@ -51,29 +53,31 @@ final class QueryClientMetrics {
         _metricsConfig.exporters.isNotEmpty) {
       _exportTimer = Timer.periodic(
         _metricsConfig.exportInterval,
-        (timer) async {
-          final snapshot = _performanceMonitor.getSnapshot();
-          for (final exporter in _metricsConfig.exporters) {
-            try {
-              await exporter.export(snapshot);
-            } on Object catch (_) {
-              // Exporter-level logging is delegated to exporters.
-            }
-          }
-        },
+        (timer) => unawaited(_exportSnapshotIfIdle()),
       );
     }
   }
 
   /// Triggers an immediate export to all configured exporters.
   Future<void> exportMetricsManually() async {
-    final snapshot = _performanceMonitor.getSnapshot();
-    for (final exporter in _metricsConfig.exporters) {
-      try {
-        await exporter.export(snapshot);
-      } on Object catch (_) {
-        // Exporter-level logging is delegated to exporters.
+    await _exportSnapshotIfIdle();
+  }
+
+  Future<void> _exportSnapshotIfIdle() async {
+    if (_isExporting) return;
+    _isExporting = true;
+    try {
+      final snapshot = _performanceMonitor.getSnapshot();
+      final exporters = _metricsConfig.exporters;
+      for (final exporter in exporters) {
+        try {
+          await exporter.export(snapshot);
+        } on Object catch (_) {
+          // Exporter-level logging is delegated to exporters.
+        }
       }
+    } finally {
+      _isExporting = false;
     }
   }
 

--- a/packages/fasq/lib/src/mutation/sync_engine/projection/projection.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/projection/projection.dart
@@ -300,15 +300,19 @@ enum ProjectionRepairAction { replace, discard }
 
 class ProjectionCoordinator {
   ProjectionCoordinator({required this.registry, ProjectionState? state})
-    : _state = state ?? ProjectionState();
+    : _state = state ?? ProjectionState() {
+    _rebuildOverlayIndex();
+  }
 
   final ProjectionRegistry registry;
   ProjectionState _state;
+  final Map<String, List<ProjectionOverlay>> _overlaysByQueryKey = {};
   ProjectionState get state => _state;
 
   /// Restores durable projection state after the outbox has opened.
   void restore(ProjectionState state) {
     _state = state;
+    _rebuildOverlayIndex();
   }
 
   ProjectionOutcome enqueue(ProjectionOverlay overlay) {
@@ -340,6 +344,13 @@ class ProjectionCoordinator {
         for (final id in stored.temporaryIds.values) id: null,
       },
     );
+    for (final key in stored.plan.queryKeys) {
+      _overlaysByQueryKey
+          .putIfAbsent(key, () => <ProjectionOverlay>[])
+          .add(
+            stored,
+          );
+    }
     return ProjectionOutcome(_state, stored.plan.queryKeys);
   }
 
@@ -373,13 +384,9 @@ class ProjectionCoordinator {
   ProjectionView materialize(QueryKey key) {
     Object? value = _state.remoteBases[key.key];
     ProjectionFailure? failure;
-    final overlays = [..._state.overlays]
-      ..sort((a, b) => a.sequence.compareTo(b.sequence));
-    for (final overlay in overlays.where(
-      (item) =>
-          item.state != ProjectionOverlayState.resolved &&
-          item.patches.containsKey(key.key),
-    )) {
+    final overlays = _overlaysByQueryKey[key.key] ?? const [];
+    for (final overlay in overlays) {
+      if (overlay.state == ProjectionOverlayState.resolved) continue;
       final definition = registry.find(overlay.plan);
       if (definition == null) {
         failure = ProjectionFailure(
@@ -422,6 +429,7 @@ class ProjectionCoordinator {
         overlays: [..._state.overlays]..removeAt(index),
         idMappings: _state.idMappings,
       );
+      _removeOverlayFromIndex(overlay);
       return ProjectionOutcome(_state, overlay.plan.queryKeys);
     } on Object {
       return _error(index, 'projection.reconcile_failed');
@@ -615,6 +623,7 @@ class ProjectionCoordinator {
       overlays: overlays,
       idMappings: {..._state.idMappings, temporaryId: serverId},
     );
+    _rebuildOverlayIndex();
     return ProjectionOutcome(_state, changedKeys.toList());
   }
 
@@ -631,7 +640,35 @@ class ProjectionCoordinator {
       overlays: [..._state.overlays]..removeAt(index),
       idMappings: _state.idMappings,
     );
+    _removeOverlayFromIndex(overlay);
     return ProjectionOutcome(_state, overlay.plan.queryKeys);
+  }
+
+  void _rebuildOverlayIndex() {
+    _overlaysByQueryKey.clear();
+    for (final overlay in _state.overlays) {
+      for (final key in overlay.plan.queryKeys) {
+        _overlaysByQueryKey
+            .putIfAbsent(key, () => <ProjectionOverlay>[])
+            .add(
+              overlay,
+            );
+      }
+    }
+    for (final overlays in _overlaysByQueryKey.values) {
+      overlays.sort((left, right) => left.sequence.compareTo(right.sequence));
+    }
+  }
+
+  void _removeOverlayFromIndex(ProjectionOverlay target) {
+    for (final key in target.plan.queryKeys) {
+      final overlays = _overlaysByQueryKey[key];
+      if (overlays == null) continue;
+      overlays.removeWhere(
+        (overlay) => overlay.operationId == target.operationId,
+      );
+      if (overlays.isEmpty) _overlaysByQueryKey.remove(key);
+    }
   }
 
   ProjectionOutcome _error(int index, String key) {

--- a/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/replay/replay_coordinator.dart
@@ -143,8 +143,13 @@ class DurableReplayCoordinator {
     RetryPolicy retryPolicy = const RetryPolicy(),
     AuthSessionProvider? authSessionProvider,
     bool Function()? isOnline,
+    this.maxConcurrentOperations = 4,
     this.ownsStore = true,
-  }) : _store = store,
+  }) : assert(
+         maxConcurrentOperations > 0,
+         'maxConcurrentOperations must be positive',
+       ),
+       _store = store,
        _registrations = registrations,
        _now = now ?? DateTime.now,
        _executionAdapter =
@@ -166,6 +171,9 @@ class DurableReplayCoordinator {
 
   /// Whether this coordinator owns the durable store lifecycle.
   final bool ownsStore;
+
+  /// Maximum number of independent ready operations executed together.
+  final int maxConcurrentOperations;
   final AuthScopeGate _authScopeGate = const AuthScopeGate();
   Future<void> _tail = Future<void>.value();
   bool _isOpen = false;
@@ -229,71 +237,58 @@ class DurableReplayCoordinator {
           await _persistDiagnostics(selection);
         }
 
-        final next = selection.orderedNodes.isEmpty
-            ? null
-            : selection.orderedNodes.first.payload;
-        if (next == null) break;
-
-        final started = await _start(next);
-        if (started == null) continue;
-        final operation = started.operation;
-        _lastServedRateLimitBucket = operation.rateLimitBucket;
-        executed.add(operation.operationId);
-
-        final context = MutationExecutionContext(
-          operationId: operation.operationId,
-          idempotencyKey: operation.idempotencyKey,
-          authPolicy: operation.authPolicy,
-          authScope: operation.authScope,
-          conflictPolicy: operation.conflictPolicy,
-          conflictPrecondition: operation.conflictPrecondition,
-          attempt: operation.attemptCount,
-          cancellationToken: replayCancellationToken,
-        );
-        MutationExecutionResult execution;
-        try {
-          execution = await _executionAdapter.execute(
-            context,
-            () => _registrations.executeRegistered(
-              operation.mutationKey,
-              operation.variables,
-            ),
-          );
-        } on Object catch (error) {
-          execution = MutationExecutionFailure(
-            _classifyAdapterError(error),
-          );
+        final batch = _readyBatch(selection.orderedNodes);
+        if (batch.isEmpty) break;
+        final startedOperations = <_StartedOperation>[];
+        for (final operation in batch) {
+          final started = await _start(operation);
+          if (started != null) {
+            startedOperations.add(started);
+            _lastServedRateLimitBucket = operation.rateLimitBucket;
+            executed.add(operation.operationId);
+          }
         }
-        if (execution case MutationExecutionSuccess(:final value)) {
-          final registered = value;
-          if (registered is RegisteredMutationExecution) {
+        if (startedOperations.isEmpty) break;
+        final executions = await Future.wait(
+          startedOperations.map(
+            (started) => _executeStarted(started, replayCancellationToken),
+          ),
+        );
+        for (var index = 0; index < startedOperations.length; index++) {
+          final started = startedOperations[index];
+          final operation = started.operation;
+          final execution = executions[index];
+          final completionGeneration = startedOperations.length == 1
+              ? started.generation
+              : _store.generation;
+          if (execution case MutationExecutionSuccess(:final value)) {
+            final registered = value;
+            final result = registered is RegisteredMutationExecution
+                ? registered.projection
+                : registered;
             final completed = await _completeSuccess(
               started,
-              registered.projection,
+              result,
+              expectedGeneration: completionGeneration,
             );
             if (completed) {
-              successfulResults[operation.operationId] = registered.data;
+              successfulResults[operation.operationId] =
+                  registered is RegisteredMutationExecution
+                  ? registered.data
+                  : registered;
             } else {
               failed.add(operation.operationId);
             }
-          } else {
-            final completed = await _completeSuccess(started, registered);
-            if (completed) {
-              successfulResults[operation.operationId] = registered;
-            } else {
-              failed.add(operation.operationId);
+          } else if (execution case MutationExecutionFailure(:final failure)) {
+            failed.add(operation.operationId);
+            final action = await _completeFailure(
+              started,
+              failure,
+              expectedGeneration: completionGeneration,
+            );
+            if (action == RetryPlanAction.retry) {
+              scheduledRetries.add(operation.operationId);
             }
-          }
-          continue;
-        }
-        if (execution case MutationExecutionFailure(:final failure)) {
-          failed.add(operation.operationId);
-          final action = await _completeFailure(
-            started,
-            failure,
-          );
-          if (action == RetryPlanAction.retry) {
-            scheduledRetries.add(operation.operationId);
           }
         }
       }
@@ -307,6 +302,74 @@ class DurableReplayCoordinator {
         successfulResults: successfulResults,
       );
     });
+  }
+
+  Future<MutationExecutionResult> _executeStarted(
+    _StartedOperation started,
+    ReplayCancellationToken cancellationToken,
+  ) async {
+    final operation = started.operation;
+    final context = MutationExecutionContext(
+      operationId: operation.operationId,
+      idempotencyKey: operation.idempotencyKey,
+      authPolicy: operation.authPolicy,
+      authScope: operation.authScope,
+      conflictPolicy: operation.conflictPolicy,
+      conflictPrecondition: operation.conflictPrecondition,
+      attempt: operation.attemptCount,
+      cancellationToken: cancellationToken,
+    );
+    try {
+      return await _executionAdapter.execute(
+        context,
+        () => _registrations.executeRegistered(
+          operation.mutationKey,
+          operation.variables,
+        ),
+      );
+    } on Object catch (error) {
+      return MutationExecutionFailure(_classifyAdapterError(error));
+    }
+  }
+
+  List<MutationOperation> _readyBatch(
+    List<SyncDagNode<MutationOperation>> orderedNodes,
+  ) {
+    if (orderedNodes.isEmpty) return const <MutationOperation>[];
+    final depthById = <String, int>{};
+    for (final node in orderedNodes) {
+      var depth = 0;
+      for (final dependencyId in node.dependsOnIds) {
+        final dependencyDepth = depthById[dependencyId];
+        if (dependencyDepth != null && dependencyDepth + 1 > depth) {
+          depth = dependencyDepth + 1;
+        }
+      }
+      depthById[node.id] = depth;
+    }
+    final firstDepth = depthById[orderedNodes.first.id]!;
+    final firstId = orderedNodes.first.id;
+    final firstHasDependents = orderedNodes
+        .skip(1)
+        .any(
+          (node) => node.dependsOnIds.contains(firstId),
+        );
+    if (firstHasDependents) {
+      return <MutationOperation>[orderedNodes.first.payload];
+    }
+    final firstBucket = orderedNodes.first.payload.rateLimitBucket;
+    final batch = <MutationOperation>[];
+    for (final node in orderedNodes) {
+      if (depthById[node.id] != firstDepth) continue;
+      if (firstBucket != null &&
+          batch.isNotEmpty &&
+          node.payload.rateLimitBucket == firstBucket) {
+        continue;
+      }
+      batch.add(node.payload);
+      if (batch.length == maxConcurrentOperations) break;
+    }
+    return batch;
   }
 
   /// Closes the coordinator and releases the outbox owner marker.
@@ -616,8 +679,9 @@ class DurableReplayCoordinator {
 
   Future<bool> _completeSuccess(
     _StartedOperation started,
-    Object? result,
-  ) async {
+    Object? result, {
+    required int expectedGeneration,
+  }) async {
     final operation = started.operation;
     OutboxHistoryEntry history;
     try {
@@ -641,6 +705,7 @@ class DurableReplayCoordinator {
           disposition: MutationFailureDisposition.unknownOutcome,
           outcomeKnowledge: MutationOutcomeKnowledge.unknown,
         ),
+        expectedGeneration: expectedGeneration,
       );
       return false;
     }
@@ -663,15 +728,16 @@ class DurableReplayCoordinator {
           history: updatedHistory,
         );
       },
-      expectedGeneration: started.generation,
+      expectedGeneration: expectedGeneration,
     );
     return true;
   }
 
   Future<RetryPlanAction> _completeFailure(
     _StartedOperation started,
-    MutationAdapterFailure failure,
-  ) async {
+    MutationAdapterFailure failure, {
+    required int expectedGeneration,
+  }) async {
     final operation = started.operation;
     final plan = _retryPolicy.plan(
       operation: operation,
@@ -715,7 +781,7 @@ class DurableReplayCoordinator {
             metadata: metadata,
           );
         },
-        expectedGeneration: started.generation,
+        expectedGeneration: expectedGeneration,
       );
       return plan.action;
     }
@@ -786,7 +852,7 @@ class DurableReplayCoordinator {
           ],
         );
       },
-      expectedGeneration: started.generation,
+      expectedGeneration: expectedGeneration,
     );
     return plan.action;
   }

--- a/packages/fasq/lib/src/mutation/sync_engine/store/file_durable_outbox.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/store/file_durable_outbox.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fasq/src/mutation/sync_engine/models/mutation_operation.dart';
 import 'package:fasq/src/mutation/sync_engine/store/durable_outbox.dart';
 import 'package:fasq/src/mutation/sync_engine/store/outbox_envelope.dart';
 import 'package:fasq/src/mutation/sync_engine/store/outbox_errors.dart';
@@ -139,6 +140,24 @@ class IoOutboxFileSystem implements OutboxFileSystem {
       throw const DurableOutboxException(
         DurableOutboxErrorCode.storage,
         'The durable outbox could not be durably written',
+      );
+    }
+  }
+
+  /// Appends bytes and flushes them before acknowledging.
+  Future<void> append(String path, List<int> bytes) async {
+    try {
+      final file = await File(path).open(mode: FileMode.append);
+      try {
+        await file.writeFrom(bytes);
+        await file.flush();
+      } finally {
+        await file.close();
+      }
+    } on FileSystemException {
+      throw const DurableOutboxException(
+        DurableOutboxErrorCode.storage,
+        'The durable outbox journal could not be durably written',
       );
     }
   }
@@ -307,6 +326,7 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
       '${identityHashCode(Object())}';
   late final String _storePath = p.join(_directoryPath, 'outbox.json');
   late final String _backupPath = p.join(_directoryPath, 'outbox.json.bak');
+  late final String _journalPath = p.join(_directoryPath, 'outbox.json.log');
   late final String _lockPath = p.join(_directoryPath, 'outbox.lock');
   late final String _temporaryPath = p.join(
     _directoryPath,
@@ -322,7 +342,13 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
   int _generation = 0;
   bool _isOpen = false;
   bool _ownsLock = false;
+  bool _journalMode = false;
+  int _fullWriteCount = 0;
+  int _journalEntryCount = 0;
   Future<void> _tail = Future<void>.value();
+
+  static const int _journalModeThreshold = 8;
+  static const int _journalCompactionThreshold = 256;
 
   /// Whether this backend currently owns the store.
   bool get isOpen => _isOpen;
@@ -366,6 +392,8 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
             await _write(_snapshot, generation: _generation + 1);
             _generation++;
           }
+          _journalMode = loaded.hasJournal;
+          _journalEntryCount = loaded.journalEntryCount;
         }
         _isOpen = true;
         _recovery = null;
@@ -410,9 +438,22 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
         throw const OutboxGenerationConflictException();
       }
       final next = transaction(_snapshot);
-      securityPolicy.validate(next.toJson());
       final generation = _generation + 1;
-      await _write(next, generation: generation);
+      if (_shouldUseJournal()) {
+        await _appendJournal(_snapshot, next, generation: generation);
+        _journalEntryCount++;
+        if (_journalEntryCount >= _journalCompactionThreshold) {
+          await _compactJournal(next, generation: generation);
+          _journalEntryCount = 0;
+        }
+      } else {
+        await _write(next, generation: generation);
+        _fullWriteCount++;
+        if (_fullWriteCount >= _journalModeThreshold) {
+          _journalMode = true;
+          await _copyPrimaryToBackup();
+        }
+      }
       _snapshot = next;
       _generation = generation;
       return next;
@@ -434,11 +475,12 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
   Future<_LoadedOutbox?> _load() async {
     final hasPrimary = await fileSystem.exists(_storePath);
     final hasBackup = await fileSystem.exists(_backupPath);
+    final hasJournal = await fileSystem.exists(_journalPath);
     if (!hasPrimary && !hasBackup) return null;
 
     if (hasPrimary) {
       try {
-        return await _readSource(_storePath);
+        return await _readSourceWithJournal(_storePath, hasJournal);
       } on OutboxMigrationRequiredException {
         rethrow;
       } on OutboxCorruptException {
@@ -448,7 +490,7 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
 
     if (!hasBackup) throw const OutboxCorruptException();
     try {
-      final loaded = await _readSource(_backupPath);
+      final loaded = await _readSourceWithJournal(_backupPath, hasJournal);
       await _restoreBackup();
       return loaded;
     } on OutboxMigrationRequiredException {
@@ -457,6 +499,67 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
       await _preserveEvidence(_backupPath);
       throw const OutboxCorruptException();
     }
+  }
+
+  Future<_LoadedOutbox> _readSourceWithJournal(
+    String path,
+    bool hasJournal,
+  ) async {
+    final loaded = await _readSource(path);
+    if (!hasJournal) return loaded;
+
+    final bytes = await fileSystem.read(_journalPath);
+    if (bytes.isEmpty) {
+      return _LoadedOutbox(
+        snapshot: loaded.snapshot,
+        generation: loaded.generation,
+        wasMigrated: loaded.wasMigrated,
+        hasJournal: true,
+        journalEntryCount: 0,
+      );
+    }
+
+    var snapshot = loaded.snapshot;
+    var generation = loaded.generation;
+    var appliedEntries = 0;
+    final lines = utf8.decode(bytes).split('\n');
+    for (final rawLine in lines) {
+      final line = rawLine.trim();
+      if (line.isEmpty) continue;
+      try {
+        final envelope = _decodeEnvelope(utf8.encode(line));
+        if (envelope.schemaVersion > currentOutboxSchemaVersion) {
+          throw const OutboxMigrationRequiredException();
+        }
+        final encrypted = _decodeEncryptedPayload(envelope.payload);
+        if (_checksum(encrypted) != envelope.checksum) {
+          throw const OutboxCorruptException();
+        }
+        final payload = _decodeObject(
+          utf8.decode(await _encryption.decrypt(encrypted)),
+        );
+        if (envelope.generation <= generation) continue;
+        if (envelope.generation != generation + 1) {
+          throw const OutboxCorruptException();
+        }
+        snapshot = _applyDelta(snapshot, payload);
+        generation = envelope.generation;
+        appliedEntries++;
+      } on OutboxMigrationRequiredException {
+        rethrow;
+      } on OutboxCorruptException {
+        throw const OutboxCorruptException();
+      } on Object {
+        throw const OutboxCorruptException();
+      }
+    }
+    return _LoadedOutbox(
+      snapshot: snapshot,
+      generation: generation,
+      wasMigrated: loaded.wasMigrated,
+      hasJournal: true,
+      journalEntryCount: appliedEntries,
+    );
   }
 
   Future<_LoadedOutbox> _readSource(String path) async {
@@ -529,6 +632,209 @@ class FileDurableOutbox implements RecoverableDurableOutboxStore {
       await fileSystem.rename(_backupTemporaryPath, _backupPath);
     }
     await fileSystem.rename(_temporaryPath, _storePath);
+  }
+
+  bool _shouldUseJournal() {
+    return _journalMode && capacity.maxBytes == null;
+  }
+
+  Future<void> _appendJournal(
+    OutboxSnapshot current,
+    OutboxSnapshot next, {
+    required int generation,
+  }) async {
+    final delta = _buildDelta(current, next);
+    securityPolicy.validate(delta);
+    final plaintext = utf8.encode(jsonEncode(delta));
+    final encrypted = await _encryption.encrypt(plaintext);
+    final envelope = OutboxEnvelope(
+      schemaVersion: currentOutboxSchemaVersion,
+      generation: generation,
+      checksum: _checksum(encrypted),
+      payload: base64Encode(encrypted),
+    );
+    final bytes = utf8.encode('${jsonEncode(envelope.toJson())}\n');
+    if (fileSystem is IoOutboxFileSystem) {
+      await (fileSystem as IoOutboxFileSystem).append(_journalPath, bytes);
+    } else {
+      final existing = await fileSystem.exists(_journalPath)
+          ? await fileSystem.read(_journalPath)
+          : const <int>[];
+      await fileSystem.write(_journalPath, <int>[...existing, ...bytes]);
+    }
+  }
+
+  Future<void> _compactJournal(
+    OutboxSnapshot snapshot, {
+    required int generation,
+  }) async {
+    await _write(snapshot, generation: generation);
+    await _copyPrimaryToBackup();
+    await fileSystem.delete(_journalPath);
+  }
+
+  Future<void> _copyPrimaryToBackup() async {
+    final primary = await fileSystem.read(_storePath);
+    await fileSystem.write(_backupTemporaryPath, primary);
+    await fileSystem.rename(_backupTemporaryPath, _backupPath);
+  }
+
+  Map<String, Object?> _buildDelta(
+    OutboxSnapshot current,
+    OutboxSnapshot next,
+  ) => {
+    'active': _collectionDelta(
+      current.active,
+      next.active,
+      id: (item) => item.operationId.value,
+      encode: (item) => item.toJson(),
+    ),
+    'deadLetters': _collectionDelta(
+      current.deadLetters,
+      next.deadLetters,
+      id: (item) => item.operation.operationId.value,
+      encode: (item) => item.toJson(),
+    ),
+    'history': _collectionDelta(
+      current.history,
+      next.history,
+      id: (item) => item.operationId.value,
+      encode: (item) => item.toJson(),
+    ),
+    'unknownRecords': _collectionDelta(
+      current.unknownRecords,
+      next.unknownRecords,
+      id: (item) => '${item.kind.name}:${item.recordId}',
+      encode: (item) => item.toJson(),
+    ),
+    if (!identical(current.metadata, next.metadata)) 'metadata': next.metadata,
+  };
+
+  Map<String, Object?> _collectionDelta<T>(
+    List<T> current,
+    List<T> next, {
+    required String Function(T item) id,
+    required Map<String, Object?> Function(T item) encode,
+  }) {
+    final previous = <String, T>{for (final item in current) id(item): item};
+    final nextIds = <String>{};
+    final upserts = <Object?>[];
+    for (final item in next) {
+      final itemId = id(item);
+      nextIds.add(itemId);
+      if (!identical(previous[itemId], item)) upserts.add(encode(item));
+    }
+    final removals = <String>[];
+    for (final item in current) {
+      final itemId = id(item);
+      if (!nextIds.contains(itemId)) removals.add(itemId);
+    }
+    return <String, Object?>{'upsert': upserts, 'remove': removals};
+  }
+
+  OutboxSnapshot _applyDelta(
+    OutboxSnapshot current,
+    Map<String, Object?> delta,
+  ) {
+    final active = _hasCollectionChanges(delta['active'])
+        ? _applyCollection(
+            current.active,
+            delta['active'],
+            id: (item) => item.operationId.value,
+            decode: MutationOperation.fromJson,
+          )
+        : null;
+    final deadLetters = _hasCollectionChanges(delta['deadLetters'])
+        ? _applyCollection(
+            current.deadLetters,
+            delta['deadLetters'],
+            id: (item) => item.operation.operationId.value,
+            decode: OutboxDeadLetter.fromJson,
+          )
+        : null;
+    final history = _hasCollectionChanges(delta['history'])
+        ? _applyCollection(
+            current.history,
+            delta['history'],
+            id: (item) => item.operationId.value,
+            decode: OutboxHistoryEntry.fromJson,
+          )
+        : null;
+    final unknownRecords = _hasCollectionChanges(delta['unknownRecords'])
+        ? _applyCollection(
+            current.unknownRecords,
+            delta['unknownRecords'],
+            id: (item) => '${item.kind.name}:${item.recordId}',
+            decode: OutboxUnknownRecord.fromJson,
+          )
+        : null;
+    return current.copyWith(
+      active: active,
+      deadLetters: deadLetters,
+      history: history,
+      unknownRecords: unknownRecords,
+      metadata: delta.containsKey('metadata')
+          ? _decodeObjectMap(delta['metadata']!)
+          : null,
+    );
+  }
+
+  bool _hasCollectionChanges(Object? value) {
+    if (value is! Map<Object?, Object?>) {
+      throw const OutboxCorruptException();
+    }
+    final delta = _decodeObjectMap(value);
+    final upsert = delta['upsert'];
+    final remove = delta['remove'];
+    if (upsert is! List<Object?> || remove is! List<Object?>) {
+      throw const OutboxCorruptException();
+    }
+    return upsert.isNotEmpty || remove.isNotEmpty;
+  }
+
+  List<T> _applyCollection<T>(
+    List<T> current,
+    Object? rawDelta, {
+    required String Function(T item) id,
+    required T Function(Map<String, Object?> json) decode,
+  }) {
+    if (rawDelta is! Map<Object?, Object?>) {
+      throw const OutboxCorruptException();
+    }
+    final delta = _decodeObjectMap(rawDelta);
+    final rawUpserts = delta['upsert'];
+    final rawRemovals = delta['remove'];
+    if (rawUpserts is! List<Object?> || rawRemovals is! List<Object?>) {
+      throw const OutboxCorruptException();
+    }
+    final removals = rawRemovals.whereType<String>().toSet();
+    if (removals.length != rawRemovals.length) {
+      throw const OutboxCorruptException();
+    }
+    final byId = <String, T>{
+      for (final item in current)
+        if (!removals.contains(id(item))) id(item): item,
+    };
+    for (final raw in rawUpserts) {
+      if (raw is! Map<Object?, Object?>) {
+        throw const OutboxCorruptException();
+      }
+      final item = decode(_decodeObjectMap(raw));
+      byId[id(item)] = item;
+    }
+    return byId.values.toList(growable: false);
+  }
+
+  Map<String, Object?> _decodeObjectMap(Object value) {
+    if (value is! Map<Object?, Object?>) {
+      throw const OutboxCorruptException();
+    }
+    final result = <String, Object?>{};
+    for (final entry in value.entries) {
+      if (entry.key is! String) throw const OutboxCorruptException();
+      result[entry.key! as String] = entry.value;
+    }
+    return result;
   }
 
   Future<void> _restoreBackup() async {
@@ -651,9 +957,13 @@ class _LoadedOutbox {
     required this.snapshot,
     required this.generation,
     required this.wasMigrated,
+    this.hasJournal = false,
+    this.journalEntryCount = 0,
   });
 
   final OutboxSnapshot snapshot;
   final int generation;
   final bool wasMigrated;
+  final bool hasJournal;
+  final int journalEntryCount;
 }

--- a/packages/fasq/lib/src/mutation/sync_engine/store/outbox_models.dart
+++ b/packages/fasq/lib/src/mutation/sync_engine/store/outbox_models.dart
@@ -301,6 +301,14 @@ class OutboxSnapshot {
        unknownRecords = List.unmodifiable(unknownRecords),
        metadata = _immutableJsonMap(metadata, 'metadata');
 
+  OutboxSnapshot._internal({
+    required this.active,
+    required this.deadLetters,
+    required this.history,
+    required this.unknownRecords,
+    required this.metadata,
+  });
+
   /// Recreates a snapshot from validated JSON.
   factory OutboxSnapshot.fromJson(Map<String, Object?> json) {
     try {
@@ -361,12 +369,16 @@ class OutboxSnapshot {
     List<OutboxUnknownRecord>? unknownRecords,
     Map<String, Object?>? metadata,
   }) {
-    return OutboxSnapshot(
-      active: active ?? this.active,
-      deadLetters: deadLetters ?? this.deadLetters,
-      history: history ?? this.history,
-      unknownRecords: unknownRecords ?? this.unknownRecords,
-      metadata: metadata ?? this.metadata,
+    return OutboxSnapshot._internal(
+      active: active == null ? this.active : List.unmodifiable(active),
+      deadLetters: deadLetters == null
+          ? this.deadLetters
+          : List.unmodifiable(deadLetters),
+      history: history == null ? this.history : List.unmodifiable(history),
+      unknownRecords: unknownRecords == null
+          ? this.unknownRecords
+          : List.unmodifiable(unknownRecords),
+      metadata: metadata == null ? this.metadata : Map.unmodifiable(metadata),
     );
   }
 

--- a/packages/fasq/lib/src/observability/performance/isolate_pool.dart
+++ b/packages/fasq/lib/src/observability/performance/isolate_pool.dart
@@ -19,6 +19,7 @@ class _IsolateWorker {
   /// The current task being processed
   IsolateTask<dynamic, dynamic>? _currentTask;
   StreamSubscription<dynamic>? _currentSubscription;
+  Future<void>? _restartFuture;
 
   /// Queue of pending tasks for this worker
   final List<IsolateTask<dynamic, dynamic>> _taskQueue = [];
@@ -38,13 +39,20 @@ class _IsolateWorker {
   Future<R> execute<T, R>(
     IsolateTask<T, R> task, {
     Duration timeout = const Duration(seconds: 30),
+    int maxQueueSize = 100,
   }) async {
     if (_isDisposed) {
       task.completeError(const IsolateExecutionException('Worker is disposed'));
       return task.completer.future;
     }
 
-    if (_currentTask != null) {
+    if (_currentTask != null && _taskQueue.length >= maxQueueSize) {
+      task.completeError(
+        IsolateExecutionException(
+          'Worker queue is full (limit $maxQueueSize)',
+        ),
+      );
+    } else if (_currentTask != null) {
       _taskQueue.add(task);
     } else {
       _runTask(task);
@@ -61,11 +69,43 @@ class _IsolateWorker {
         },
       );
     } on Object catch (e) {
+      if (task.isCancelled) {
+        await _restartAfterTimeout();
+      }
       if (!task.isCancelled) {
         task.completeError(e);
       }
       rethrow;
     }
+  }
+
+  Future<void> _restartAfterTimeout() {
+    final existing = _restartFuture;
+    if (existing != null) return existing;
+
+    final restart = () async {
+      final pending = List<IsolateTask<dynamic, dynamic>>.from(_taskQueue);
+      _taskQueue.clear();
+      await _currentSubscription?.cancel();
+      _currentSubscription = null;
+      _currentTask = null;
+      _isolate?.kill(priority: Isolate.immediate);
+      _receivePort?.close();
+      _isolate = null;
+      _sendPort = null;
+      _receivePort = null;
+      try {
+        await initialize();
+        _taskQueue.addAll(pending);
+        _processNextTask();
+      } on Object catch (error, stackTrace) {
+        for (final task in pending) {
+          task.completeError(error, stackTrace);
+        }
+      }
+    }();
+    _restartFuture = restart;
+    return restart.whenComplete(() => _restartFuture = null);
   }
 
   /// Process the next task in the queue
@@ -216,13 +256,18 @@ void _isolateEntryPoint(SendPort sendPort) {
 /// with automatic work distribution, lifecycle management, and error handling.
 class IsolatePool {
   /// Create an isolate pool with the specified number of workers
-  IsolatePool({this.poolSize = 2})
-      : assert(poolSize > 0, 'Pool size must be greater than 0') {
+  IsolatePool({this.poolSize = 2, int? maxQueuedTasks})
+    : assert(poolSize > 0, 'Pool size must be greater than 0') {
+    this.maxQueuedTasks = maxQueuedTasks ?? poolSize * 50;
+    assert(this.maxQueuedTasks > 0, 'maxQueuedTasks must be greater than 0');
     _initialization = _initializeWorkers();
   }
 
   /// Number of worker isolates managed by this pool.
   final int poolSize;
+
+  /// Maximum queued tasks across all workers.
+  late final int maxQueuedTasks;
   final List<_IsolateWorker> _workers = [];
   int _currentWorkerIndex = 0;
   bool _isDisposed = false;
@@ -247,8 +292,9 @@ class IsolatePool {
   /// that can be serialized and sent to an isolate.
   Future<R> execute<T, R>(
     FutureOr<R> Function(T message) callback,
-    T message,
-  ) async {
+    T message, {
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
     if (_isDisposed) {
       throw const IsolateExecutionException('Isolate pool is disposed');
     }
@@ -290,7 +336,17 @@ class IsolatePool {
     }
 
     try {
-      return await selectedWorker.execute(task);
+      final queuedTasks = status.totalQueuedTasks;
+      if (queuedTasks >= maxQueuedTasks && selectedWorker.isBusy) {
+        throw IsolateExecutionException(
+          'Isolate pool queue is full (limit $maxQueuedTasks)',
+        );
+      }
+      return await selectedWorker.execute(
+        task,
+        timeout: timeout,
+        maxQueueSize: maxQueuedTasks,
+      );
     } on Object catch (e) {
       throw IsolateExecutionException('Task execution failed', e);
     }
@@ -341,8 +397,10 @@ class IsolatePool {
   /// Get the current status of the isolate pool
   IsolatePoolStatus get status {
     final busyWorkers = _workers.where((w) => w.isBusy).length;
-    final totalQueuedTasks =
-        _workers.fold<int>(0, (sum, w) => sum + w._taskQueue.length);
+    final totalQueuedTasks = _workers.fold<int>(
+      0,
+      (sum, w) => sum + w._taskQueue.length,
+    );
 
     return IsolatePoolStatus(
       totalWorkers: poolSize,

--- a/packages/fasq/test/cache/cache_metrics_test.dart
+++ b/packages/fasq/test/cache/cache_metrics_test.dart
@@ -1,0 +1,51 @@
+import 'package:fasq/src/cache/cache_metrics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('throughput windows retain exact rolling counts after expiry', () {
+    var now = DateTime.utc(2026, 1, 1);
+    final metrics = CacheMetrics(now: () => now);
+
+    metrics.recordQueryExecution('todos');
+    metrics.recordQueryExecution('todos');
+    expect(
+      metrics
+          .calculateThroughput(
+            'todos',
+            window: const Duration(seconds: 1),
+          )
+          ?.totalRequests,
+      2,
+    );
+
+    now = now.add(const Duration(seconds: 2));
+    metrics.recordQueryExecution('todos');
+    expect(
+      metrics
+          .calculateThroughput(
+            'todos',
+            window: const Duration(seconds: 1),
+          )
+          ?.totalRequests,
+      1,
+    );
+    expect(
+      metrics
+          .calculateThroughput(
+            'todos',
+            window: const Duration(seconds: 5),
+          )
+          ?.totalRequests,
+      3,
+    );
+
+    now = now.add(const Duration(minutes: 16));
+    expect(
+      metrics.calculateThroughput(
+        'todos',
+        window: const Duration(minutes: 1),
+      ),
+      isNull,
+    );
+  });
+}

--- a/packages/fasq/test/mutation/sync_engine/store/file_durable_outbox_test.dart
+++ b/packages/fasq/test/mutation/sync_engine/store/file_durable_outbox_test.dart
@@ -37,6 +37,37 @@ void main() {
     await store.close();
   });
 
+  test(
+    'switches to encrypted append journal for sustained mutations',
+    () async {
+      final store = _newStore(directory, _FakeOutboxEncryption());
+      await store.open();
+
+      for (var index = 1; index <= 10; index++) {
+        await store.transact(
+          (current) => current.copyWith(
+            active: [
+              ...current.active,
+              _operation('operation-$index'),
+            ],
+          ),
+        );
+      }
+      await store.close();
+
+      expect(File('${directory.path}/outbox.json.log').existsSync(), isTrue);
+      final recovered = _newStore(directory, _FakeOutboxEncryption());
+      await recovered.open();
+      expect(recovered.generation, 10);
+      expect(recovered.snapshot.active, hasLength(10));
+      expect(
+        recovered.snapshot.active.last.operationId.value,
+        'operation-10',
+      );
+      await recovered.close();
+    },
+  );
+
   test('restores the last-known-good backup without clearing work', () async {
     final encryption = _FakeOutboxEncryption();
     final first = _newStore(directory, encryption);

--- a/packages/fasq/test/observability/performance/isolate_pool_test.dart
+++ b/packages/fasq/test/observability/performance/isolate_pool_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fasq/src/observability/performance/isolate_pool.dart';
 import 'package:fasq/src/observability/performance/isolate_task.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,8 +17,12 @@ void main() {
     });
 
     test('executes synchronous work and returns result', () async {
-      final result =
-          await pool.execute<List<int>, int>(_sumReducer, [1, 2, 3, 4]);
+      final result = await pool.execute<List<int>, int>(_sumReducer, [
+        1,
+        2,
+        3,
+        4,
+      ]);
       expect(result, 10);
     });
 
@@ -42,6 +48,23 @@ void main() {
         throwsA(isA<IsolateExecutionException>()),
       );
     });
+
+    test(
+      'restarts a worker after timeout instead of retaining stuck work',
+      () async {
+        await expectLater(
+          pool.execute<int, int>(
+            _neverCompletes,
+            5,
+            timeout: const Duration(milliseconds: 10),
+          ),
+          throwsA(isA<IsolateExecutionException>()),
+        );
+
+        final result = await pool.execute<int, int>(_delayedIdentity, 9);
+        expect(result, 9);
+      },
+    );
   });
 }
 
@@ -62,6 +85,8 @@ Future<int> _delayedIdentity(int value) async {
   await Future<void>.delayed(const Duration(milliseconds: 10));
   return value;
 }
+
+Future<int> _neverCompletes(int value) => Completer<int>().future;
 
 int _throwingWork(int value) {
   throw StateError('failed on $value');


### PR DESCRIPTION
## Summary

- Replace repeated durable outbox snapshot rewrites with encrypted delta journaling and bounded compaction.
- Batch independent replay operations while preserving dependency and rate-limit ordering.
- Make cache sizing, persisted loading, projections, LRU maintenance, and rolling metrics incremental or indexed.
- Bound isolate queues and restart workers after execution timeouts.

## Verification

- flutter test packages/fasq/test/cache packages/fasq/test/mutation/sync_engine packages/fasq/test/observability/performance — 190 tests passed.
- Touched-area flutter analyze — no analyzer errors; existing info diagnostics remain.
- dart format and git diff --check pass.

## Commits

- c60591a perf(outbox): Add encrypted delta journaling
- 37bff6e perf(sync): Batch replay and index projections
- a50ae5a perf(cache): Make cache and metrics accounting incremental
- 31d9045 perf(runtime): Bound isolate queues and recover timed-out workers