### PR TITLE
feat: Add full-parity hooks adapter

### DIFF
--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -27,6 +27,7 @@ export 'src/mutation/durable_mutation_catalog.dart';
 export 'src/mutation/durable_mutation_definition.dart';
 export 'src/mutation/durable_mutation_queue.dart';
 export 'src/mutation/mutation.dart';
+export 'src/mutation/mutation_factory.dart';
 export 'src/mutation/mutation_contract.dart';
 export 'src/mutation/mutation_meta.dart';
 export 'src/mutation/mutation_options.dart';

--- a/packages/fasq/lib/src/cache/query_cache.dart
+++ b/packages/fasq/lib/src/cache/query_cache.dart
@@ -117,6 +117,7 @@ class QueryCache {
   /// this method before disposing a cache or handing its storage to another
   /// owner.
   Future<void> flushPersistence() async {
+    if (persistenceOptions?.enabled != true) return;
     final initFuture = _persistenceInitFuture;
     if (initFuture != null) await initFuture;
 
@@ -1202,7 +1203,7 @@ class QueryCache {
 
   Future<void> _disposePersistenceResources() async {
     final initFuture = _persistenceInitFuture;
-    if (initFuture != null) {
+    if (persistenceOptions?.enabled == true && initFuture != null) {
       try {
         await initFuture;
       } on Object catch (_) {}

--- a/packages/fasq/lib/src/client/internal/query_client_registry.dart
+++ b/packages/fasq/lib/src/client/internal/query_client_registry.dart
@@ -11,15 +11,16 @@ import 'package:fasq/src/query/query_options.dart';
 import 'package:flutter/foundation.dart';
 
 /// Factory used by [QueryClientRegistry] to create [Query] instances.
-typedef QueryClientQueryFactory = Query<T> Function<T>({
-  required QueryKey queryKey,
-  required QueryDependencyManager dependencyManager,
-  required void Function() onDispose,
-  Future<T> Function()? queryFn,
-  Future<T> Function(CancellationToken token)? queryFnWithToken,
-  QueryOptions? options,
-  CacheEntry<T>? initialEntry,
-});
+typedef QueryClientQueryFactory =
+    Query<T> Function<T>({
+      required QueryKey queryKey,
+      required QueryDependencyManager dependencyManager,
+      required void Function() onDispose,
+      Future<T> Function()? queryFn,
+      Future<T> Function(CancellationToken token)? queryFnWithToken,
+      QueryOptions? options,
+      CacheEntry<T>? initialEntry,
+    });
 
 /// Owns in-memory query registries and related lifecycle operations.
 final class QueryClientRegistry {
@@ -27,8 +28,8 @@ final class QueryClientRegistry {
   QueryClientRegistry({
     required QueryCache cache,
     required QueryClientQueryFactory queryFactory,
-  })  : _cache = cache,
-        _queryFactory = queryFactory;
+  }) : _cache = cache,
+       _queryFactory = queryFactory;
 
   final QueryCache _cache;
   final QueryClientQueryFactory _queryFactory;
@@ -96,6 +97,38 @@ final class QueryClientRegistry {
     return query;
   }
 
+  /// Reconfigures a registered query without replacing its instance.
+  Query<T> reconfigureQuery<T>(
+    QueryKey queryKey, {
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+    QueryKey? dependsOn,
+  }) {
+    final existing = _queries[queryKey.key];
+    if (existing == null || existing.isDisposed) {
+      return getQuery<T>(
+        queryKey,
+        queryFn: queryFn,
+        queryFnWithToken: queryFnWithToken,
+        options: options,
+        dependsOn: dependsOn,
+      );
+    }
+    if (dependsOn == null) {
+      _dependencyManager.removeParent(queryKey.key);
+    } else {
+      _dependencyManager.registerDependency(queryKey.key, dependsOn.key);
+    }
+    final query = existing as Query<T>;
+    query.reconfigure(
+      queryFn: queryFn,
+      queryFnWithToken: queryFnWithToken,
+      options: options,
+    );
+    return query;
+  }
+
   /// Gets an existing infinite query or creates a new one.
   InfiniteQuery<TData, TParam> getInfiniteQuery<TData, TParam>(
     QueryKey queryKey,
@@ -124,6 +157,25 @@ final class QueryClientRegistry {
 
     _infiniteQueries[key] = infinite as InfiniteQuery<Object?, Object?>;
     return infinite;
+  }
+
+  /// Reconfigures a registered infinite query without replacing its instance.
+  InfiniteQuery<TData, TParam> reconfigureInfiniteQuery<TData, TParam>(
+    QueryKey queryKey,
+    Future<TData> Function(TParam param) queryFn, {
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    final existing = _infiniteQueries[queryKey.key];
+    if (existing == null || existing.isDisposed) {
+      return getInfiniteQuery<TData, TParam>(
+        queryKey,
+        queryFn,
+        options: options,
+      );
+    }
+    final query = existing as InfiniteQuery<TData, TParam>;
+    query.reconfigure(queryFn: queryFn, options: options);
+    return query;
   }
 
   /// Retrieves an existing query by key.

--- a/packages/fasq/lib/src/client/query_client.dart
+++ b/packages/fasq/lib/src/client/query_client.dart
@@ -310,6 +310,24 @@ class QueryClient with WidgetsBindingObserver {
     );
   }
 
+  /// Reconfigures a query while preserving its identity, state, cache, and
+  /// active listeners.
+  Query<T> reconfigureQuery<T>(
+    QueryKey queryKey, {
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+    QueryKey? dependsOn,
+  }) {
+    return _registry.reconfigureQuery<T>(
+      queryKey,
+      queryFn: queryFn,
+      queryFnWithToken: queryFnWithToken,
+      options: options,
+      dependsOn: dependsOn,
+    );
+  }
+
   /// Gets an existing infinite query or creates a new one.
   InfiniteQuery<TData, TParam> getInfiniteQuery<TData, TParam>(
     QueryKey queryKey,
@@ -317,6 +335,19 @@ class QueryClient with WidgetsBindingObserver {
     InfiniteQueryOptions<TData, TParam>? options,
   }) {
     return _registry.getInfiniteQuery<TData, TParam>(
+      queryKey,
+      queryFn,
+      options: options,
+    );
+  }
+
+  /// Reconfigures an infinite query while preserving its pages and listeners.
+  InfiniteQuery<TData, TParam> reconfigureInfiniteQuery<TData, TParam>(
+    QueryKey queryKey,
+    Future<TData> Function(TParam param) queryFn, {
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    return _registry.reconfigureInfiniteQuery<TData, TParam>(
       queryKey,
       queryFn,
       options: options,
@@ -516,6 +547,7 @@ class QueryClient with WidgetsBindingObserver {
   /// Only use this in tests to get a fresh instance.
   static Future<void> resetForTesting() async {
     Query.disposalDelay = Duration.zero;
+    InfiniteQuery.disposalDelay = Duration.zero;
     QueryCache.gcInterval = Duration.zero;
     QueryCache.persistenceGcInterval = Duration.zero;
 

--- a/packages/fasq/lib/src/mutation/mutation_factory.dart
+++ b/packages/fasq/lib/src/mutation/mutation_factory.dart
@@ -1,0 +1,42 @@
+import 'package:fasq/src/client/query_client.dart';
+import 'package:fasq/src/mutation/durable_mutation_catalog.dart';
+import 'package:fasq/src/mutation/durable_mutation_queue.dart';
+import 'package:fasq/src/mutation/mutation.dart';
+import 'package:fasq/src/mutation/mutation_contract.dart';
+import 'package:fasq/src/mutation/mutation_options.dart';
+
+/// Creates mutations from either ordinary functions or bootstrapped durable
+/// mutation keys.
+final class MutationFactory {
+  const MutationFactory._();
+
+  /// Creates a mutation from a registered durable [key].
+  static Mutation<TData, TVariables> fromKey<TData, TVariables>({
+    required FasqMutationKey<TData, TVariables> key,
+    required DurableMutationCatalog catalog,
+    required DurableMutationQueue queue,
+    QueryClient? client,
+    MutationOptions<TData, TVariables>? options,
+  }) {
+    final definition = catalog.resolve(key);
+    final effectiveOptions = definition.bind(queue, base: options);
+    return Mutation<TData, TVariables>(
+      mutationFn: definition.execute,
+      options: effectiveOptions,
+      client: client,
+    );
+  }
+
+  /// Creates an ordinary non-durable mutation.
+  static Mutation<TData, TVariables> fromFunction<TData, TVariables>({
+    required Future<TData> Function(TVariables variables) mutationFn,
+    QueryClient? client,
+    MutationOptions<TData, TVariables>? options,
+  }) {
+    return Mutation<TData, TVariables>(
+      mutationFn: mutationFn,
+      options: options,
+      client: client,
+    );
+  }
+}

--- a/packages/fasq/lib/src/query/dependency/query_dependency_manager.dart
+++ b/packages/fasq/lib/src/query/dependency/query_dependency_manager.dart
@@ -73,6 +73,20 @@ class QueryDependencyManager {
     }
   }
 
+  /// Removes only the parent relationship for [childKey].
+  ///
+  /// Unlike [unregister], this keeps the query's children intact. It is used
+  /// when an existing query changes its dependency without being disposed.
+  void removeParent(String childKey) {
+    final parent = _childToParent.remove(childKey);
+    if (parent == null) return;
+    final children = _parentToChildren[parent];
+    children?.remove(childKey);
+    if (children?.isEmpty ?? false) {
+      _parentToChildren.remove(parent);
+    }
+  }
+
   /// Returns all direct child keys for a given parent.
   Set<String> getChildren(String parentKey) {
     return Set.unmodifiable(_parentToChildren[parentKey] ?? {});

--- a/packages/fasq/lib/src/query/infinite/infinite_query.dart
+++ b/packages/fasq/lib/src/query/infinite/infinite_query.dart
@@ -57,8 +57,8 @@ class InfiniteQuery<TData, TParam> {
     this.cache,
     this.onDispose,
     List<Page<TData, TParam>>? initialPages,
-  })  : key = queryKey.key,
-        _currentState = InfiniteQueryState<TData, TParam>.idle() {
+  }) : key = queryKey.key,
+       _currentState = InfiniteQueryState<TData, TParam>.idle() {
     if (initialPages != null && initialPages.isNotEmpty) {
       final opts = options;
       final hasNext = _computeHasNextForPages(opts, initialPages);
@@ -82,10 +82,10 @@ class InfiniteQuery<TData, TParam> {
   final String key;
 
   /// Page fetch function invoked with a page parameter.
-  final Future<TData> Function(TParam param) queryFn;
+  Future<TData> Function(TParam param) queryFn;
 
   /// Optional behavior configuration for this infinite query.
-  final InfiniteQueryOptions<TData, TParam>? options;
+  InfiniteQueryOptions<TData, TParam>? options;
 
   /// Optional cache integration used for lifecycle and prefetch behavior.
   final QueryCache? cache;
@@ -100,6 +100,10 @@ class InfiniteQuery<TData, TParam> {
   bool _isDisposed = false;
   Future<void>? _fetchFuture;
   bool _isPrefetching = false;
+  int _operationGeneration = 0;
+
+  /// Delay before an inactive infinite query is disposed.
+  static Duration disposalDelay = const Duration(seconds: 5);
 
   /// Broadcast stream of query state updates.
   Stream<InfiniteQueryState<TData, TParam>> get stream => _controller.stream;
@@ -213,24 +217,29 @@ class InfiniteQuery<TData, TParam> {
   Future<void> fetchNextPage([TParam? overrideParam]) async {
     if (_isDisposed || options?.enabled == false) return;
     if (_fetchFuture != null) return;
-    _fetchFuture = _fetchNextPageImpl(overrideParam);
+    final generation = _operationGeneration;
+    final future = _fetchNextPageImpl(overrideParam, generation);
+    _fetchFuture = future;
     try {
-      await _fetchFuture;
+      await future;
     } finally {
-      _fetchFuture = null;
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
     }
   }
 
-  Future<void> _fetchNextPageImpl([TParam? overrideParam]) async {
-    if (_isDisposed || options?.enabled == false) return;
+  Future<void> _fetchNextPageImpl(
+    TParam? overrideParam,
+    int generation,
+  ) async {
+    if (_isStaleOperation(generation) || options?.enabled == false) return;
     final pages = _currentState.pages;
     final nextParam = overrideParam ?? _computeNextParam(pages);
     if (nextParam == null) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       _updateState(_currentState.copyWith(hasNextPage: false));
       return;
     }
-    if (_isDisposed) return;
+    if (_isStaleOperation(generation)) return;
     _updateState(
       _currentState.copyWith(
         isFetchingNextPage: true,
@@ -239,7 +248,7 @@ class InfiniteQuery<TData, TParam> {
     );
     try {
       final data = await queryFn(nextParam);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final newPage = Page<TData, TParam>(param: nextParam).withData(data);
       final newPages = [...pages, newPage];
       final capped = _applyMaxPages(newPages, dropFromStart: true);
@@ -251,7 +260,7 @@ class InfiniteQuery<TData, TParam> {
       );
       options?.onSuccess?.call();
     } on Object catch (e, s) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final errorPage = Page<TData, TParam>(param: nextParam).withError(e, s);
       final newPages = [...pages, errorPage];
       final capped = _applyMaxPages(newPages, dropFromStart: true);
@@ -300,28 +309,30 @@ class InfiniteQuery<TData, TParam> {
   Future<void> fetchPreviousPage() async {
     if (_isDisposed || options?.enabled == false) return;
     if (_fetchFuture != null) return;
-    _fetchFuture = _fetchPreviousPageImpl();
+    final generation = _operationGeneration;
+    final future = _fetchPreviousPageImpl(generation);
+    _fetchFuture = future;
     try {
-      await _fetchFuture;
+      await future;
     } finally {
-      _fetchFuture = null;
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
     }
   }
 
-  Future<void> _fetchPreviousPageImpl() async {
-    if (_isDisposed || options?.enabled == false) return;
+  Future<void> _fetchPreviousPageImpl(int generation) async {
+    if (_isStaleOperation(generation) || options?.enabled == false) return;
     final pages = _currentState.pages;
     final prevParam = _computePreviousParam(pages);
     if (prevParam == null) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       _updateState(_currentState.copyWith(hasPreviousPage: false));
       return;
     }
-    if (_isDisposed) return;
+    if (_isStaleOperation(generation)) return;
     _updateState(_currentState.copyWith(isFetchingPreviousPage: true));
     try {
       final data = await queryFn(prevParam);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final newPage = Page<TData, TParam>(param: prevParam).withData(data);
       final newPages = [newPage, ...pages];
       final capped = _applyMaxPages(newPages, dropFromStart: false);
@@ -333,7 +344,7 @@ class InfiniteQuery<TData, TParam> {
       );
       options?.onSuccess?.call();
     } on Object catch (e, s) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final errorPage = Page<TData, TParam>(param: prevParam).withError(e, s);
       final newPages = [errorPage, ...pages];
       final capped = _applyMaxPages(newPages, dropFromStart: false);
@@ -376,12 +387,27 @@ class InfiniteQuery<TData, TParam> {
     if (_fetchFuture != null) return;
     final pages = _currentState.pages;
     if (index < 0 || index >= pages.length) return;
+    final generation = _operationGeneration;
     final page = pages[index];
+    final future = _refetchPageImpl(index, page, generation);
+    _fetchFuture = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
+    }
+  }
+
+  Future<void> _refetchPageImpl(
+    int index,
+    Page<TData, TParam> page,
+    int generation,
+  ) async {
     try {
       final data = await queryFn(page.param);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final updated = page.withData(data);
-      final newPages = [...pages];
+      final newPages = [..._currentState.pages];
       newPages[index] = updated;
       _updateStateWithPages(
         newPages,
@@ -389,13 +415,13 @@ class InfiniteQuery<TData, TParam> {
         dataUpdatedAt: DateTime.now(),
       );
       options?.onSuccess?.call();
-    } on Object catch (e, s) {
-      if (_isDisposed) return;
-      final updated = page.withError(e, s);
-      final newPages = [...pages];
+    } on Object catch (error, stackTrace) {
+      if (_isStaleOperation(generation)) return;
+      final updated = page.withError(error, stackTrace);
+      final newPages = [..._currentState.pages];
       newPages[index] = updated;
       _updateStateWithPages(newPages);
-      options?.onError?.call(e);
+      options?.onError?.call(error);
     }
   }
 
@@ -410,6 +436,7 @@ class InfiniteQuery<TData, TParam> {
   /// query.reset();
   /// ```
   void reset() {
+    _operationGeneration++;
     _fetchFuture = null;
     _updateState(InfiniteQueryState<TData, TParam>.idle());
   }
@@ -438,6 +465,28 @@ class InfiniteQuery<TData, TParam> {
       status: QueryStatus.success,
       dataUpdatedAt: DateTime.now(),
     );
+  }
+
+  /// Replaces the fetch configuration while preserving this query instance,
+  /// pages, state, and listeners.
+  void reconfigure({
+    required Future<TData> Function(TParam param) queryFn,
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    _operationGeneration++;
+    _fetchFuture = null;
+    this.queryFn = queryFn;
+    this.options = options;
+    _updateState(
+      _currentState.copyWith(
+        hasNextPage: _computeHasNext(_currentState.pages),
+        hasPreviousPage: _computeHasPrev(_currentState.pages),
+      ),
+    );
+  }
+
+  bool _isStaleOperation(int generation) {
+    return _isDisposed || generation != _operationGeneration;
   }
 
   void _updateState(InfiniteQueryState<TData, TParam> newState) {
@@ -560,7 +609,11 @@ class InfiniteQuery<TData, TParam> {
   }
 
   void _scheduleDisposal() {
-    _disposeTimer = Timer(const Duration(seconds: 5), () {
+    if (disposalDelay == Duration.zero) {
+      if (_referenceCount == 0) dispose();
+      return;
+    }
+    _disposeTimer = Timer(disposalDelay, () {
       if (_referenceCount == 0) {
         dispose();
       }

--- a/packages/fasq/lib/src/query/query.dart
+++ b/packages/fasq/lib/src/query/query.dart
@@ -95,15 +95,15 @@ class Query<T> {
     this.dependencyManager,
     this.onDispose,
     CacheEntry<T>? initialEntry,
-  })  : assert(
-          queryFn != null || queryFnWithToken != null,
-          'Either queryFn or queryFnWithToken must be provided',
-        ),
-        key = queryKey.key,
-        _currentState = QueryState<T>.idle(),
-        _debugCreationStack = kDebugMode ? StackTrace.current : null,
-        _debugHolders = kDebugMode ? <Object, StackTrace>{} : null,
-        _debugHolderOrder = kDebugMode ? <Object>[] : null {
+  }) : assert(
+         queryFn != null || queryFnWithToken != null,
+         'Either queryFn or queryFnWithToken must be provided',
+       ),
+       key = queryKey.key,
+       _currentState = QueryState<T>.idle(),
+       _debugCreationStack = kDebugMode ? StackTrace.current : null,
+       _debugHolders = kDebugMode ? <Object, StackTrace>{} : null,
+       _debugHolderOrder = kDebugMode ? <Object>[] : null {
     _controller = StreamController<QueryState<T>>.broadcast();
 
     // Set initial state based on cache snapshot and staleness
@@ -120,17 +120,17 @@ class Query<T> {
   /// The async function that fetches the data.
   ///
   /// // TODO(fasq): Deprecate in favor of queryFnWithToken in next major version
-  final Future<T> Function()? queryFn;
+  Future<T> Function()? queryFn;
 
   /// The async function that fetches data with cancellation support.
   ///
   /// Use this instead of [queryFn] to enable cooperative cancellation.
   /// The [CancellationToken] can be checked during long operations or passed
   /// to HTTP clients that support cancellation.
-  final Future<T> Function(CancellationToken token)? queryFnWithToken;
+  Future<T> Function(CancellationToken token)? queryFnWithToken;
 
   /// Optional configuration for this query.
-  final QueryOptions? options;
+  QueryOptions? options;
 
   /// The cache instance for storing results.
   final QueryCache? cache;
@@ -275,10 +275,10 @@ class Query<T> {
 
   /// Get performance metrics for this query
   QueryMetrics get metrics => QueryMetrics(
-        fetchHistory: List.from(_fetchHistory),
-        lastFetchDuration: _lastFetchDuration,
-        referenceCount: _referenceCount,
-      );
+    fetchHistory: List.from(_fetchHistory),
+    lastFetchDuration: _lastFetchDuration,
+    referenceCount: _referenceCount,
+  );
 
   /// Creates a query function that can be used with _executeFetch.
   ///
@@ -311,11 +311,11 @@ class Query<T> {
       final estimatedSize = _estimateDataFootprint(data);
       if (estimatedSize >= threshold) {
         try {
-          final transformed =
-              await client!.isolatePool.execute<_TransformPayload<T>, T?>(
-            _runDataTransformerTask,
-            _TransformPayload<T>(data: data, transformer: transformer),
-          );
+          final transformed = await client!.isolatePool
+              .execute<_TransformPayload<T>, T?>(
+                _runDataTransformerTask,
+                _TransformPayload<T>(data: data, transformer: transformer),
+              );
           if (transformed != null) {
             return transformed;
           }
@@ -672,6 +672,25 @@ class Query<T> {
     );
   }
 
+  /// Replaces the executable configuration while preserving this query's
+  /// cache, state, listeners, and identity.
+  void reconfigure({
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+  }) {
+    if (queryFn == null && queryFnWithToken == null) {
+      throw ArgumentError(
+        'Either queryFn or queryFnWithToken must be provided',
+      );
+    }
+    cancel();
+    this.queryFn = queryFn;
+    this.queryFnWithToken = queryFnWithToken;
+    this.options = options;
+    _updateState(_currentState);
+  }
+
   void _updateState(QueryState<T> newState) {
     _currentState = newState;
     if (!_controller.isClosed) {
@@ -781,8 +800,9 @@ class Query<T> {
     if (manager == null || queryClient == null) return;
 
     manager.notifyParentDisposed(key, (childKey) {
-      final childQuery =
-          queryClient.getQueryByKey<Object>(StringQueryKey(childKey));
+      final childQuery = queryClient.getQueryByKey<Object>(
+        StringQueryKey(childKey),
+      );
       childQuery?.cancel();
     });
   }

--- a/packages/fasq/lib/src/widgets/mutation_builder.dart
+++ b/packages/fasq/lib/src/widgets/mutation_builder.dart
@@ -4,6 +4,7 @@ import 'package:fasq/src/client/query_client.dart';
 import 'package:fasq/src/mutation/durable_mutation_definition.dart';
 import 'package:fasq/src/mutation/durable_mutation_queue.dart';
 import 'package:fasq/src/mutation/mutation.dart';
+import 'package:fasq/src/mutation/mutation_factory.dart';
 import 'package:fasq/src/mutation/mutation_contract.dart';
 import 'package:fasq/src/mutation/mutation_options.dart';
 import 'package:fasq/src/mutation/mutation_snapshot.dart';
@@ -150,11 +151,19 @@ class _MutationBuilderState<T, TVariables>
     _effectiveOptions = durableDefinition == null
         ? widget.options
         : durableDefinition.bind(durableQueue!, base: widget.options);
-    _mutation = Mutation<T, TVariables>(
-      mutationFn: mutationFn,
-      options: _effectiveOptions,
-      client: _client,
-    );
+    _mutation = durableDefinition == null
+        ? MutationFactory.fromFunction<T, TVariables>(
+            mutationFn: mutationFn,
+            options: _effectiveOptions,
+            client: _client,
+          )
+        : MutationFactory.fromKey<T, TVariables>(
+            key: widget.mutationKey!,
+            catalog: FasqProvider.of(context).mutations,
+            queue: durableQueue!,
+            options: widget.options,
+            client: _client,
+          );
     _state = _mutation.state;
 
     _subscription = _mutation.stream.listen((state) {

--- a/packages/fasq/test/client/query_reconfigure_test.dart
+++ b/packages/fasq/test/client/query_reconfigure_test.dart
@@ -1,0 +1,53 @@
+import 'package:fasq/fasq.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    Query.disposalDelay = Duration.zero;
+    InfiniteQuery.disposalDelay = Duration.zero;
+    QueryCache.gcInterval = Duration.zero;
+  });
+
+  tearDown(() async => QueryClient.resetForTesting());
+
+  test('reconfigures a standard query in place', () async {
+    final client = QueryClient();
+    final key = 'reconfigure'.toQueryKey();
+    final query = client.getQuery<String>(
+      key,
+      queryFn: () async => 'old',
+    );
+    query.addListener();
+    await query.fetch(forceRefetch: true);
+
+    final reconfigured = client.reconfigureQuery<String>(
+      key,
+      queryFn: () async => 'new',
+    );
+    expect(identical(reconfigured, query), isTrue);
+    await reconfigured.fetch(forceRefetch: true);
+    expect(reconfigured.state.data, 'new');
+  });
+
+  test('reconfigures an infinite query in place', () async {
+    final client = QueryClient();
+    final key = 'infinite-reconfigure'.toQueryKey();
+    final query = client.getInfiniteQuery<List<int>, int>(
+      key,
+      (page) async => [page],
+      options: InfiniteQueryOptions<List<int>, int>(
+        getNextPageParam: (pages, last) => pages.length < 1 ? 1 : null,
+      ),
+    );
+    await query.addListener();
+    await query.fetchNextPage();
+
+    final reconfigured = client.reconfigureInfiniteQuery<List<int>, int>(
+      key,
+      (page) async => [page + 10],
+    );
+    expect(identical(reconfigured, query), isTrue);
+    await reconfigured.refetchPage(0);
+    expect(reconfigured.state.pages.single.data, [11]);
+  });
+}

--- a/packages/fasq_hooks/example/lib/main.dart
+++ b/packages/fasq_hooks/example/lib/main.dart
@@ -37,7 +37,7 @@ class GreetingsScreen extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final client = useQueryClient();
-    final state = useQuery<List<String>>(greetingsKey, fetchGreetings);
+    final state = useQuery<List<String>>(greetingsKey, queryFn: fetchGreetings);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Greetings via Hooks')),

--- a/packages/fasq_hooks/lib/fasq_hooks.dart
+++ b/packages/fasq_hooks/lib/fasq_hooks.dart
@@ -10,5 +10,6 @@ export 'src/use_query_client.dart';
 export 'src/use_infinite_query.dart';
 export 'src/use_queries.dart';
 export 'src/use_prefetch.dart';
+export 'src/use_mutation_queue.dart';
 
 export 'package:fasq/fasq.dart';

--- a/packages/fasq_hooks/lib/src/use_infinite_query.dart
+++ b/packages/fasq_hooks/lib/src/use_infinite_query.dart
@@ -1,44 +1,99 @@
 import 'dart:async';
 
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Observes an [InfiniteQuery] from a HookWidget and returns its state.
-///
-/// The hook handles listener lifecycle automatically and keeps pagination
-/// metadata in sync with the backing query instance.
-InfiniteQueryState<TData, TParam> useInfiniteQuery<TData, TParam>(
+import 'use_query_client.dart';
+
+/// Returns reactive infinite-query state and pagination commands.
+UseInfiniteQueryResult<TData, TParam> useInfiniteQuery<TData, TParam>(
   QueryKey queryKey,
   Future<TData> Function(TParam param) queryFn, {
   InfiniteQueryOptions<TData, TParam>? options,
   QueryClient? client,
 }) {
   final queryClient = useQueryClient(client: client);
-
-  final state = useState<InfiniteQueryState<TData, TParam>>(
-    InfiniteQueryState.idle(),
+  final query = useMemoized(
+    () => queryClient.getInfiniteQuery<TData, TParam>(
+      queryKey,
+      queryFn,
+      options: options,
+    ),
+    [queryClient, queryKey.key],
   );
+  final state = useState<InfiniteQueryState<TData, TParam>>(query.state);
+  final hasMounted = useRef(false);
 
   useEffect(() {
-    final query = queryClient.getInfiniteQuery<TData, TParam>(
+    final shouldReconfigure = hasMounted.value;
+    hasMounted.value = true;
+    final configuredQuery = queryClient.reconfigureInfiniteQuery<TData, TParam>(
       queryKey,
       queryFn,
       options: options,
     );
-
-    query.addListener();
-
-    final subscription = query.stream.listen((newState) {
-      state.value = newState;
+    configuredQuery.addListener();
+    state.value = configuredQuery.state;
+    final subscription = configuredQuery.stream.listen((nextState) {
+      state.value = nextState;
     });
-
-    state.value = query.state;
-
+    if (options?.refetchOnMount == true || shouldReconfigure) {
+      if (shouldReconfigure) configuredQuery.reset();
+      unawaited(configuredQuery.fetchNextPage());
+    }
     return () {
-      subscription.cancel();
-      query.removeListener();
+      unawaited(subscription.cancel());
+      configuredQuery.removeListener();
     };
-  }, [queryKey.key]);
+  }, [queryClient, queryKey.key, queryFn, options]);
 
-  return state.value;
+  return UseInfiniteQueryResult<TData, TParam>(
+    client: queryClient,
+    query: query,
+    state: state.value,
+  );
+}
+
+/// Reactive state and commands for one infinite query.
+class UseInfiniteQueryResult<TData, TParam> {
+  /// Creates an infinite query result.
+  const UseInfiniteQueryResult({
+    required this.client,
+    required this.query,
+    required this.state,
+  });
+
+  /// Client owning the query.
+  final QueryClient client;
+
+  /// Shared infinite-query instance.
+  final InfiniteQuery<TData, TParam> query;
+
+  /// Current pagination state.
+  final InfiniteQueryState<TData, TParam> state;
+
+  /// Fetches the next page.
+  Future<void> fetchNextPage([TParam? parameter]) =>
+      query.fetchNextPage(parameter);
+
+  /// Fetches the previous page.
+  Future<void> fetchPreviousPage() => query.fetchPreviousPage();
+
+  /// Refetches one existing page.
+  Future<void> refetchPage(int index) => query.refetchPage(index);
+
+  /// Clears all pages and returns to idle state.
+  void reset() => query.reset();
+
+  /// Invalidates this query in the shared client cache.
+  void invalidate() => client.invalidateQuery(query.queryKey);
+
+  /// Removes this query from the client registry.
+  void remove() => client.removeInfiniteQuery(query.queryKey);
+
+  /// Whether another forward page is available.
+  bool get hasNextPage => query.hasNextPage;
+
+  /// Whether another backward page is available.
+  bool get hasPreviousPage => query.hasPreviousPage;
 }

--- a/packages/fasq_hooks/lib/src/use_mutation.dart
+++ b/packages/fasq_hooks/lib/src/use_mutation.dart
@@ -1,71 +1,177 @@
 import 'dart:async';
 
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Creates a FASQ [Mutation] and exposes its state through a hook.
-///
-/// The returned [UseMutationResult] provides imperative mutate/reset callbacks
-/// together with reactive status flags that update as the mutation progresses.
-UseMutationResult<TData, TVariables> useMutation<TData, TVariables>(
-  Future<TData> Function(TVariables variables) mutationFn, {
+import 'use_query_client.dart';
+
+/// Creates either an ordinary or a runtime-registered durable mutation.
+UseMutationResult<TData, TVariables> useMutation<TData, TVariables>({
+  Future<TData> Function(TVariables variables)? mutationFn,
+  FasqMutationKey<TData, TVariables>? mutationKey,
   MutationOptions<TData, TVariables>? options,
+  QueryClient? client,
   void Function(TData data)? onSuccess,
   void Function(Object error)? onError,
 }) {
-  final state = useState<MutationState<TData>>(const MutationState.idle());
-  final mutation = useMemoized(
-    () => Mutation<TData, TVariables>(
-      mutationFn: mutationFn,
-      options:
-          options ??
-          MutationOptions<TData, TVariables>(
-            onSuccess: onSuccess,
-            onError: onError,
-          ),
-    ),
+  assert(
+    (mutationFn == null) != (mutationKey == null),
+    'Provide exactly one of mutationFn or mutationKey.',
   );
+  final queryClient = useQueryClient(client: client);
+  final context = useContext();
+  final runtime = FasqProvider.maybeOf(context);
+  if (mutationKey != null && runtime == null) {
+    throw StateError(
+      'Mutation ${mutationKey.value} requires a FasqProvider runtime.',
+    );
+  }
+  final successCallback = useRef<void Function(TData)?>(onSuccess);
+  successCallback.value = onSuccess;
+  final errorCallback = useRef<void Function(Object)?>(onError);
+  errorCallback.value = onError;
+  final effectiveOptions = useMemoized(
+    () => _mergeCallbacks(
+      options,
+      (data) => successCallback.value?.call(data),
+      (error) => errorCallback.value?.call(error),
+    ),
+    [options],
+  );
+  final mutationFunction =
+      useRef<Future<TData> Function(TVariables variables)?>(mutationFn);
+  mutationFunction.value = mutationFn;
+  final stableMutationFunction = useMemoized(
+    () => (TVariables variables) {
+      final current = mutationFunction.value;
+      if (current == null) {
+        throw StateError('An ordinary mutation function is required.');
+      }
+      return current(variables);
+    },
+    const [],
+  );
+  final mutation = useMemoized(() {
+    if (mutationKey != null) {
+      final durableQueue = runtime?.mutationQueue;
+      if (durableQueue == null) {
+        throw StateError(
+          'Mutation ${mutationKey.value} requires OfflineSync and a '
+          'FasqProvider runtime.',
+        );
+      }
+      return MutationFactory.fromKey<TData, TVariables>(
+        key: mutationKey,
+        catalog: runtime!.mutations,
+        queue: durableQueue,
+        options: effectiveOptions,
+        client: queryClient,
+      );
+    }
+    return MutationFactory.fromFunction<TData, TVariables>(
+      mutationFn: stableMutationFunction,
+      options: effectiveOptions,
+      client: queryClient,
+    );
+  }, [queryClient, runtime, mutationKey?.runtimeKey, effectiveOptions]);
+  final state = useState<MutationState<TData>>(mutation.state);
 
   useEffect(() {
-    final subscription = mutation.stream.listen((newState) {
-      state.value = newState;
-    });
-
     state.value = mutation.state;
-
+    final subscription = mutation.stream.listen((nextState) {
+      state.value = nextState;
+    });
     return () {
-      subscription.cancel();
+      unawaited(subscription.cancel());
       mutation.dispose();
     };
   }, [mutation]);
 
-  return UseMutationResult(
-    mutate: mutation.mutate,
-    reset: mutation.reset,
+  return UseMutationResult<TData, TVariables>(
+    mutation: mutation,
     state: state.value,
   );
 }
 
-/// Convenience wrapper returned by [useMutation].
-///
-/// Exposes the imperative [mutate] and [reset] callbacks alongside the latest
-/// [MutationState] and boolean helpers for common checks.
+MutationOptions<TData, TVariables>? _mergeCallbacks<TData, TVariables>(
+  MutationOptions<TData, TVariables>? options,
+  void Function(TData data)? onSuccess,
+  void Function(Object error)? onError,
+) {
+  if (onSuccess == null && onError == null) return options;
+  return MutationOptions<TData, TVariables>(
+    onSuccess: (data) {
+      options?.onSuccess?.call(data);
+      onSuccess?.call(data);
+    },
+    onError: (error) {
+      options?.onError?.call(error);
+      onError?.call(error);
+    },
+    onMutate: options?.onMutate,
+    queueWhenOffline: options?.queueWhenOffline ?? false,
+    durableQueue: options?.durableQueue,
+    resultEncoder: options?.resultEncoder,
+    projectionPlan: options?.projectionPlan,
+    projectionBuilder: options?.projectionBuilder,
+    maxRetries: options?.maxRetries,
+    onQueued: options?.onQueued,
+    priority: options?.priority ?? 0,
+    meta: options?.meta,
+  );
+}
+
+/// Reactive state and commands for one mutation.
 class UseMutationResult<TData, TVariables> {
-  final Future<void> Function(TVariables) mutate;
-  final void Function() reset;
+  /// Creates a mutation result.
+  const UseMutationResult({required this.mutation, required this.state});
+
+  /// Underlying core mutation.
+  final Mutation<TData, TVariables> mutation;
+
+  /// Current mutation state.
   final MutationState<TData> state;
 
-  const UseMutationResult({
-    required this.mutate,
-    required this.reset,
-    required this.state,
-  });
+  /// Submits the mutation and returns its durable outcome.
+  Future<MutationSubmission<TData>> mutate(TVariables variables) {
+    return mutation.submit(variables);
+  }
 
+  /// Alias for [mutate] matching the core mutation API.
+  Future<MutationSubmission<TData>> submit(TVariables variables) {
+    return mutation.submit(variables);
+  }
+
+  /// Resets the mutation to idle.
+  void reset() => mutation.reset();
+
+  /// Whether the mutation is currently loading.
   bool get isLoading => state.isLoading;
-  bool get hasData => state.hasData;
-  bool get hasError => state.hasError;
-  bool get isIdle => state.isIdle;
+
+  /// Whether the mutation is queued for later replay.
+  bool get isQueued => state.isQueued;
+
+  /// Whether the mutation succeeded.
   bool get isSuccess => state.isSuccess;
+
+  /// Whether the mutation failed.
+  bool get isError => state.isError;
+
+  /// Whether the mutation is idle.
+  bool get isIdle => state.isIdle;
+
+  /// Whether successful data exists.
+  bool get hasData => state.hasData;
+
+  /// Whether an error exists.
+  bool get hasError => state.hasError;
+
+  /// Latest result data.
   TData? get data => state.data;
+
+  /// Latest error.
   Object? get error => state.error;
+
+  /// Latest error stack trace.
+  StackTrace? get stackTrace => state.stackTrace;
 }

--- a/packages/fasq_hooks/lib/src/use_mutation_queue.dart
+++ b/packages/fasq_hooks/lib/src/use_mutation_queue.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:fasq/fasq.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'use_query_client.dart';
+
+/// Observes and controls the durable queue exposed by the nearest runtime.
+UseMutationQueueResult useMutationQueue({DurableOperationFilter? filter}) {
+  final runtime = useFasqRuntime();
+  final queue = runtime.mutationQueue;
+  if (queue == null) {
+    throw StateError(
+      'useMutationQueue requires OfflineSync to be configured in Fasq.',
+    );
+  }
+  final observation = useState<DurableQueueObservation>(queue.observation);
+
+  useEffect(() {
+    observation.value = queue.observation;
+    final subscription = queue.watch(filter: filter).listen((nextObservation) {
+      observation.value = nextObservation;
+    });
+    return () => unawaited(subscription.cancel());
+  }, [queue, filter]);
+
+  return UseMutationQueueResult(queue: queue, observation: observation.value);
+}
+
+/// Reactive queue observation plus the complete durable queue command surface.
+class UseMutationQueueResult {
+  /// Creates a queue result.
+  const UseMutationQueueResult({
+    required this.queue,
+    required this.observation,
+  });
+
+  /// Underlying core queue for advanced APIs.
+  final DurableMutationQueue queue;
+
+  /// Current filtered public-safe observation.
+  final DurableQueueObservation observation;
+
+  /// Current persisted outbox snapshot.
+  OutboxSnapshot get snapshot => queue.snapshot;
+
+  /// Whether the durable outbox is open.
+  bool get isOpen => queue.isOpen;
+
+  /// Whether the configured connectivity source reports online.
+  bool get isOnline => queue.isOnline;
+
+  /// Current durable-store generation.
+  int get generation => queue.generation;
+
+  /// Recovery diagnostics, when the outbox could not be opened cleanly.
+  DurableOutboxRecovery? get recovery => queue.recovery;
+
+  /// Current aggregate state.
+  DurableQueueAggregateState get aggregateState => observation.aggregateState;
+
+  /// Current projection state, when configured.
+  ProjectionState? get projectionState => queue.projectionState;
+
+  /// Current auth scope used for observations.
+  AuthScope? get currentAuthScope => queue.currentAuthScope;
+
+  /// Replays admissible durable operations.
+  Future<ReplayRunResult> replay({ReplayCancellationToken? cancellationToken}) {
+    return queue.replay(cancellationToken: cancellationToken);
+  }
+
+  /// Adds a restart-safe optimistic projection overlay.
+  Future<ProjectionOutcome> enqueueProjection(ProjectionOverlay overlay) {
+    return queue.enqueueProjection(overlay);
+  }
+
+  /// Applies a confirmed remote projection base.
+  Future<ProjectionOutcome> setProjectionRemoteBase(
+    QueryKey key,
+    Object? value, {
+    int? revision,
+  }) {
+    return queue.setProjectionRemoteBase(key, value, revision: revision);
+  }
+
+  /// Remaps a temporary projection identifier to its server identifier.
+  Future<ProjectionOutcome> remapProjectionId({
+    required String temporaryId,
+    required String serverId,
+  }) {
+    return queue.remapProjectionId(
+      temporaryId: temporaryId,
+      serverId: serverId,
+    );
+  }
+
+  /// Materializes the current projection view for a query key.
+  ProjectionView? materializeProjection(QueryKey key) {
+    return queue.materializeProjection(key);
+  }
+
+  /// Completes an optimistic projection after successful replay.
+  Future<ProjectionOutcome> completeProjection(
+    OperationId operationId,
+    Object? result,
+  ) {
+    return queue.completeProjection(operationId, result);
+  }
+
+  /// Removes an optimistic projection after a terminal failure.
+  Future<ProjectionOutcome> failProjection(OperationId operationId) {
+    return queue.failProjection(operationId);
+  }
+
+  /// Marks an optimistic projection as conflicted.
+  Future<ProjectionOutcome> markProjectionConflict(
+    OperationId operationId, {
+    Map<String, Object?>? conflictEvidence,
+  }) {
+    return queue.markProjectionConflict(
+      operationId,
+      conflictEvidence: conflictEvidence,
+    );
+  }
+
+  /// Returns one observed operation.
+  DurableOperationObservation? observeOperation(
+    OperationId operationId, {
+    AuthScope? authScope,
+  }) {
+    return queue.observeOperation(operationId, authScope: authScope);
+  }
+
+  /// Lists observed operations.
+  List<DurableOperationObservation> listOperations({
+    DurableOperationFilter? filter,
+  }) {
+    return queue.listOperations(filter: filter);
+  }
+
+  /// Returns retained history for one operation.
+  List<DurableHistoryObservation> operationHistory(
+    OperationId operationId, {
+    AuthScope? authScope,
+  }) {
+    return queue.operationHistory(operationId, authScope: authScope);
+  }
+
+  /// Retries one dead letter.
+  Future<RepairActionResult> retryDeadLetter({
+    required OperationId operationId,
+    required String idempotencyKey,
+    AuthScope? currentAuthScope,
+  }) {
+    return queue.retryDeadLetter(
+      operationId: operationId,
+      idempotencyKey: idempotencyKey,
+      currentAuthScope: currentAuthScope,
+    );
+  }
+
+  /// Repairs one dead letter with explicit variables.
+  Future<RepairActionResult> repairDeadLetter({
+    required OperationId operationId,
+    required String idempotencyKey,
+    required Object? variables,
+    MutationKey? mutationKey,
+    ConflictPrecondition? conflictPrecondition,
+    AuthScope? currentAuthScope,
+  }) {
+    return queue.repairDeadLetter(
+      operationId: operationId,
+      idempotencyKey: idempotencyKey,
+      variables: variables,
+      mutationKey: mutationKey,
+      conflictPrecondition: conflictPrecondition,
+      currentAuthScope: currentAuthScope,
+    );
+  }
+
+  /// Discards one dead letter while retaining its evidence.
+  Future<RepairActionResult> discardDeadLetter({
+    required OperationId operationId,
+    required String idempotencyKey,
+    AuthScope? currentAuthScope,
+  }) {
+    return queue.discardDeadLetter(
+      operationId: operationId,
+      idempotencyKey: idempotencyKey,
+      currentAuthScope: currentAuthScope,
+    );
+  }
+
+  /// Restores one quarantined operation.
+  Future<RepairActionResult> restoreQuarantinedOperation({
+    required OperationId operationId,
+    required String idempotencyKey,
+    required AuthScope currentAuthScope,
+  }) {
+    return queue.restoreQuarantinedOperation(
+      operationId: operationId,
+      idempotencyKey: idempotencyKey,
+      currentAuthScope: currentAuthScope,
+    );
+  }
+}

--- a/packages/fasq_hooks/lib/src/use_prefetch.dart
+++ b/packages/fasq_hooks/lib/src/use_prefetch.dart
@@ -1,55 +1,40 @@
 import 'dart:async';
 
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Hook that provides a callback to prefetch queries.
-///
-/// Returns a function that can be called to prefetch a query.
-/// Useful for prefetching on hover, on mount, or before navigation.
-///
-/// Example:
-/// ```dart
-/// final prefetch = usePrefetchQuery();
-///
-/// // Prefetch on hover
-/// onHover: () => prefetch('user-123', () => api.fetchUser('123')),
-/// ```
-void Function(QueryKey, Future<T> Function(), {QueryOptions? options})
+import 'use_query_client.dart';
+
+/// Returns a stable asynchronous callback for prefetching one query.
+Future<void> Function(QueryKey, Future<T> Function(), {QueryOptions? options})
 usePrefetchQuery<T>({QueryClient? client}) {
   final queryClient = useQueryClient(client: client);
-
   return useCallback((
     QueryKey queryKey,
     Future<T> Function() queryFn, {
     QueryOptions? options,
   }) {
-    queryClient.prefetchQuery(queryKey, queryFn, options: options);
-  }, []);
+    return queryClient.prefetchQuery(queryKey, queryFn, options: options);
+  }, [queryClient]);
 }
 
-/// Hook that prefetches queries on mount.
-///
-/// Useful for warming the cache for upcoming screens or tabs.
-///
-/// Example:
-/// ```dart
-/// usePrefetchOnMount([
-///   PrefetchConfig(
-///     queryKey: 'users'.toQueryKey(),
-///     queryFn: () => api.fetchUsers(),
-///   ),
-///   PrefetchConfig(
-///     queryKey: 'posts'.toQueryKey(),
-///     queryFn: () => api.fetchPosts(),
-///   ),
-/// ]);
-/// ```
-void usePrefetchOnMount(List<PrefetchConfig> configs, {QueryClient? client}) {
+/// Starts configured prefetches whenever the configuration changes.
+void usePrefetchOnMount(
+  List<PrefetchConfig<dynamic>> configs, {
+  QueryClient? client,
+}) {
   final queryClient = useQueryClient(client: client);
+  final dependencies = <Object?>[
+    queryClient,
+    for (final config in configs) ...<Object?>[
+      config.queryKey.key,
+      config.queryFn,
+      config.options,
+    ],
+  ];
 
   useEffect(() {
-    queryClient.prefetchQueries(configs);
+    unawaited(queryClient.prefetchQueries(configs));
     return null;
-  }, [configs.length]);
+  }, dependencies);
 }

--- a/packages/fasq_hooks/lib/src/use_queries.dart
+++ b/packages/fasq_hooks/lib/src/use_queries.dart
@@ -1,168 +1,238 @@
 import 'dart:async';
 
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Configuration for a single query in a parallel query setup.
+import 'use_query.dart';
+import 'use_query_client.dart';
+
+/// Configuration for one standard query in a parallel query set.
 class QueryConfig<T> {
-  /// Unique identifier for this query.
+  /// Creates a query configuration.
+  const QueryConfig(
+    this.queryKey,
+    this.queryFn, {
+    this.queryFnWithToken,
+    this.options,
+    this.dependsOn,
+  });
+
+  /// Stable query identity.
   final QueryKey queryKey;
 
-  /// Function that returns a Future with the data.
-  final Future<T> Function() queryFn;
+  /// Ordinary fetch function.
+  final Future<T> Function()? queryFn;
 
-  /// Optional configuration for this query.
+  /// Cancellation-aware fetch function.
+  final Future<T> Function(CancellationToken token)? queryFnWithToken;
+
+  /// Query behavior options.
   final QueryOptions? options;
 
-  const QueryConfig(this.queryKey, this.queryFn, {this.options});
+  /// Optional parent query dependency.
+  final QueryKey? dependsOn;
 }
 
-/// Hook that executes multiple queries in parallel and returns their states.
-///
-/// Each query executes independently and updates its state asynchronously.
-/// The hook returns a list of QueryState objects corresponding to each config.
-///
-/// Example:
-/// ```dart
-/// final queries = useQueries([
-///   QueryConfig('users', () => api.fetchUsers()),
-///   QueryConfig('posts', () => api.fetchPosts()),
-///   QueryConfig('comments', () => api.fetchComments()),
-/// ]);
-///
-/// final allLoaded = queries.every((q) => q.hasData);
-/// final anyError = queries.any((q) => q.hasError);
-/// ```
-List<QueryState<dynamic>> useQueries(
-  List<QueryConfig> configs, {
+/// Executes and observes multiple queries keyed by their query identity.
+List<UseQueryResult<dynamic>> useQueries(
+  List<QueryConfig<dynamic>> configs, {
   QueryClient? client,
 }) {
   final queryClient = useQueryClient(client: client);
-  final states = useState<List<QueryState<dynamic>>>([]);
+  final results = useState<List<UseQueryResult<dynamic>>>(const []);
+  final hasMounted = useRef(false);
+  final dependencies = _queryDependencies(queryClient, configs);
 
   useEffect(() {
+    final shouldReconfigure = hasMounted.value;
+    hasMounted.value = true;
     final queries = configs
         .map(
-          (config) => queryClient.getQuery(
+          (config) => queryClient.reconfigureQuery<dynamic>(
             config.queryKey,
             queryFn: config.queryFn,
+            queryFnWithToken: config.queryFnWithToken,
             options: config.options,
+            dependsOn: config.dependsOn,
           ),
         )
-        .toList();
+        .toList(growable: false);
+    final subscriptions = <StreamSubscription<QueryState<dynamic>>>[];
 
-    // Add listeners to all queries
-    for (final query in queries) {
+    for (var index = 0; index < queries.length; index++) {
+      final query = queries[index];
       query.addListener();
-    }
-
-    // Subscribe to state changes for each query
-    final subscriptions = <StreamSubscription>[];
-    for (int i = 0; i < queries.length; i++) {
       subscriptions.add(
-        queries[i].stream.listen((newState) {
-          final newStates = List<QueryState<dynamic>>.from(states.value);
-          newStates[i] = newState;
-          states.value = newStates;
+        query.stream.listen((state) {
+          final next = List<UseQueryResult<dynamic>>.from(results.value);
+          if (index >= next.length) return;
+          next[index] = UseQueryResult<dynamic>(
+            client: queryClient,
+            query: query,
+            state: state,
+          );
+          results.value = next;
         }),
       );
     }
 
-    // Initialize with current states
-    states.value = queries.map((q) => q.state).toList();
+    results.value = [
+      for (final query in queries)
+        UseQueryResult<dynamic>(
+          client: queryClient,
+          query: query,
+          state: query.state,
+        ),
+    ];
+    for (final query in queries) {
+      if (query.options?.refetchOnMount == true || shouldReconfigure) {
+        unawaited(
+          query.fetch(
+            forceRefetch:
+                shouldReconfigure || query.options?.refetchOnMount == true,
+          ),
+        );
+      }
+    }
 
-    // Cleanup function
     return () {
-      for (final sub in subscriptions) {
-        sub.cancel();
+      for (final subscription in subscriptions) {
+        unawaited(subscription.cancel());
       }
       for (final query in queries) {
         query.removeListener();
       }
     };
-  }, [configs.length]);
+  }, dependencies);
 
-  return states.value;
+  return results.value;
 }
 
-/// Named configuration for queries
+/// Configuration for one named query.
 class NamedQueryConfig<T> {
-  /// Name identifier for this query.
-  final String name;
-
-  /// Unique identifier for this query.
-  final QueryKey queryKey;
-
-  /// Function that returns a Future with the data.
-  final Future<T> Function() queryFn;
-
-  /// Optional configuration for this query.
-  final QueryOptions? options;
-
+  /// Creates a named query configuration.
   const NamedQueryConfig({
     required this.name,
     required this.queryKey,
-    required this.queryFn,
+    this.queryFn,
+    this.queryFnWithToken,
     this.options,
+    this.dependsOn,
   });
+
+  /// Stable UI name.
+  final String name;
+
+  /// Stable query identity.
+  final QueryKey queryKey;
+
+  /// Ordinary fetch function.
+  final Future<T> Function()? queryFn;
+
+  /// Cancellation-aware fetch function.
+  final Future<T> Function(CancellationToken token)? queryFnWithToken;
+
+  /// Query behavior options.
+  final QueryOptions? options;
+
+  /// Optional parent query dependency.
+  final QueryKey? dependsOn;
 }
 
-/// Hook for named queries with map-based access
-///
-/// Each query executes independently and updates its state asynchronously.
-/// The hook returns a map of QueryState objects keyed by query name.
-///
-/// Example:
-/// ```dart
-/// final queries = useNamedQueries([
-///   NamedQueryConfig(name: 'users', key: 'users', queryFn: () => api.fetchUsers()),
-///   NamedQueryConfig(name: 'posts', key: 'posts', queryFn: () => api.fetchPosts()),
-///   NamedQueryConfig(name: 'comments', key: 'comments', queryFn: () => api.fetchComments()),
-/// ]);
-///
-/// final allLoaded = queries.values.every((q) => q.hasData);
-/// final anyError = queries.values.any((q) => q.hasError);
-/// ```
-Map<String, QueryState<dynamic>> useNamedQueries(
-  List<NamedQueryConfig> configs, {
+/// Executes and observes named queries keyed by name and query identity.
+Map<String, UseQueryResult<dynamic>> useNamedQueries(
+  List<NamedQueryConfig<dynamic>> configs, {
   QueryClient? client,
 }) {
   final queryClient = useQueryClient(client: client);
-  final states = useState<Map<String, QueryState<dynamic>>>({});
+  final results = useState<Map<String, UseQueryResult<dynamic>>>({});
+  final hasMounted = useRef(false);
+  final dependencies = <Object?>[
+    queryClient,
+    for (final config in configs) ...<Object?>[
+      config.name,
+      config.queryKey.key,
+      config.queryFn,
+      config.queryFnWithToken,
+      config.options,
+      config.dependsOn?.key,
+    ],
+  ];
 
   useEffect(() {
-    final queries = <String, Query>{};
-    for (final config in configs) {
-      queries[config.name] = queryClient.getQuery(
-        config.queryKey,
-        queryFn: config.queryFn,
-        options: config.options,
-      );
-      queries[config.name]!.addListener();
-    }
-
-    final subscriptions = <StreamSubscription>[];
+    final shouldReconfigure = hasMounted.value;
+    hasMounted.value = true;
+    final queries = <String, Query<dynamic>>{
+      for (final config in configs)
+        config.name: queryClient.reconfigureQuery<dynamic>(
+          config.queryKey,
+          queryFn: config.queryFn,
+          queryFnWithToken: config.queryFnWithToken,
+          options: config.options,
+          dependsOn: config.dependsOn,
+        ),
+    };
+    final subscriptions = <StreamSubscription<QueryState<dynamic>>>[];
     queries.forEach((name, query) {
+      query.addListener();
       subscriptions.add(
-        query.stream.listen((newState) {
-          final newStates = Map<String, QueryState<dynamic>>.from(states.value);
-          newStates[name] = newState;
-          states.value = newStates;
+        query.stream.listen((state) {
+          final next = Map<String, UseQueryResult<dynamic>>.from(results.value);
+          next[name] = UseQueryResult<dynamic>(
+            client: queryClient,
+            query: query,
+            state: state,
+          );
+          results.value = next;
         }),
       );
     });
-
-    states.value = queries.map((name, query) => MapEntry(name, query.state));
+    results.value = {
+      for (final entry in queries.entries)
+        entry.key: UseQueryResult<dynamic>(
+          client: queryClient,
+          query: entry.value,
+          state: entry.value.state,
+        ),
+    };
+    for (final config in configs) {
+      final query = queries[config.name];
+      if (query == null) continue;
+      if (config.options?.refetchOnMount == true || shouldReconfigure) {
+        unawaited(
+          query.fetch(
+            forceRefetch:
+                shouldReconfigure || config.options?.refetchOnMount == true,
+          ),
+        );
+      }
+    }
 
     return () {
-      for (final sub in subscriptions) {
-        sub.cancel();
+      for (final subscription in subscriptions) {
+        unawaited(subscription.cancel());
       }
       for (final query in queries.values) {
         query.removeListener();
       }
     };
-  }, [configs.length]);
+  }, dependencies);
 
-  return states.value;
+  return results.value;
+}
+
+List<Object?> _queryDependencies(
+  QueryClient queryClient,
+  List<QueryConfig<dynamic>> configs,
+) {
+  return <Object?>[
+    queryClient,
+    for (final config in configs) ...<Object?>[
+      config.queryKey.key,
+      config.queryFn,
+      config.queryFnWithToken,
+      config.options,
+      config.dependsOn?.key,
+    ],
+  ];
 }

--- a/packages/fasq_hooks/lib/src/use_query.dart
+++ b/packages/fasq_hooks/lib/src/use_query.dart
@@ -1,43 +1,143 @@
 import 'dart:async';
 
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Watches a single query inside a [HookWidget] and returns its state.
-///
-/// The hook subscribes to the query when the widget is mounted and keeps the
-/// latest [QueryState] in sync with the underlying FASQ [Query]. The query is
-/// automatically disposed when the widget unmounts.
-QueryState<T> useQuery<T>(
-  QueryKey queryKey,
-  Future<T> Function() queryFn, {
+import 'use_query_client.dart';
+
+/// Returns a reactive query result with state and imperative query actions.
+UseQueryResult<T> useQuery<T>(
+  QueryKey queryKey, {
+  Future<T> Function()? queryFn,
+  Future<T> Function(CancellationToken token)? queryFnWithToken,
   QueryOptions? options,
+  QueryKey? dependsOn,
   QueryClient? client,
 }) {
+  assert(
+    queryFn != null || queryFnWithToken != null,
+    'Either queryFn or queryFnWithToken must be provided',
+  );
   final queryClient = useQueryClient(client: client);
-
-  final state = useState<QueryState<T>>(QueryState.idle());
-
-  useEffect(() {
-    final query = queryClient.getQuery<T>(
+  final query = useMemoized(
+    () => queryClient.getQuery<T>(
       queryKey,
       queryFn: queryFn,
+      queryFnWithToken: queryFnWithToken,
       options: options,
+      dependsOn: dependsOn,
+    ),
+    [queryClient, queryKey.key],
+  );
+  final state = useState<QueryState<T>>(query.state);
+  final hasMounted = useRef(false);
+
+  useEffect(
+    () {
+      final shouldReconfigure = hasMounted.value;
+      hasMounted.value = true;
+      final configuredQuery = queryClient.reconfigureQuery<T>(
+        queryKey,
+        queryFn: queryFn,
+        queryFnWithToken: queryFnWithToken,
+        options: options,
+        dependsOn: dependsOn,
+      );
+      configuredQuery.addListener();
+      state.value = configuredQuery.state;
+      final subscription = configuredQuery.stream.listen((nextState) {
+        state.value = nextState;
+      });
+      final shouldFetch = options?.refetchOnMount ?? false;
+      if (shouldFetch || shouldReconfigure) {
+        unawaited(
+          configuredQuery.fetch(forceRefetch: shouldFetch || shouldReconfigure),
+        );
+      }
+      return () {
+        unawaited(subscription.cancel());
+        configuredQuery.removeListener();
+      };
+    },
+    [queryClient, queryKey.key, queryFn, queryFnWithToken, options, dependsOn],
+  );
+
+  return UseQueryResult<T>(
+    client: queryClient,
+    query: query,
+    state: state.value,
+  );
+}
+
+/// Reactive state and commands for one standard query.
+class UseQueryResult<T> {
+  /// Creates a query result.
+  const UseQueryResult({
+    required this.client,
+    required this.query,
+    required this.state,
+  });
+
+  /// Client owning this query.
+  final QueryClient client;
+
+  /// Shared query instance.
+  final Query<T> query;
+
+  /// Current query state.
+  final QueryState<T> state;
+
+  /// Refetches the query, bypassing fresh cache data when requested.
+  Future<void> refetch({bool forceRefetch = true}) {
+    return query.fetch(forceRefetch: forceRefetch);
+  }
+
+  /// Marks this query stale and triggers the core invalidation behavior.
+  void invalidate() => client.invalidateQuery(query.queryKey);
+
+  /// Cancels the current cooperative fetch.
+  void cancel() => query.cancel();
+
+  /// Writes data through the owning client and updates active subscribers.
+  void setData(T data, {bool isSecure = false, Duration? maxAge}) {
+    client.setQueryData<T>(
+      query.queryKey,
+      data,
+      isSecure: isSecure,
+      maxAge: maxAge,
     );
+  }
 
-    query.addListener();
+  /// Removes this query instance and its retained cache entry.
+  void remove() => client.removeQuery(query.queryKey);
 
-    final subscription = query.stream.listen((newState) {
-      state.value = newState;
-    });
+  /// Query-specific performance metrics.
+  QueryMetrics get metrics => query.metrics;
 
-    state.value = query.state;
+  /// Debug lifecycle information, when available.
+  QueryDebugInfo? get debugInfo => query.debugInfo;
 
-    return () {
-      subscription.cancel();
-      query.removeListener();
-    };
-  }, [queryKey.key]);
+  /// Whether the query currently has data.
+  bool get hasData => state.hasValue;
 
-  return state.value;
+  /// Whether the query is loading.
+  bool get isLoading => state.isLoading;
+
+  /// Whether the query is successful.
+  bool get isSuccess => state.isSuccess;
+
+  /// Whether the query is idle.
+  bool get isIdle => state.isIdle;
+
+  /// Whether the query currently has an error.
+  bool get hasError => state.hasError;
+
+  /// Whether the query is fetching.
+  bool get isFetching => state.isFetching;
+
+  /// Current data value.
+  T? get data => state.data;
+
+  /// Current error value.
+  Object? get error => state.error;
 }

--- a/packages/fasq_hooks/lib/src/use_query_client.dart
+++ b/packages/fasq_hooks/lib/src/use_query_client.dart
@@ -1,12 +1,14 @@
-import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:fasq/fasq.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-/// Returns the ambient [QueryClient] instance for hook-enabled widgets.
-///
-/// A specific client can be provided for testing or isolated composition.
-/// Otherwise the nearest [QueryClientProvider] is used, with the legacy
-/// singleton retained as the compatibility fallback.
+/// Returns the explicit, runtime-provided, or legacy singleton client.
 QueryClient useQueryClient({QueryClient? client}) {
   final context = useContext();
   return client ?? context.queryClient ?? QueryClient();
+}
+
+/// Returns the nearest initialized FASQ runtime.
+FasqRuntime useFasqRuntime({FasqRuntime? runtime}) {
+  if (runtime != null) return runtime;
+  return FasqProvider.of(useContext());
 }

--- a/packages/fasq_hooks/test/use_infinite_query_test.dart
+++ b/packages/fasq_hooks/test/use_infinite_query_test.dart
@@ -1,0 +1,57 @@
+import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    QueryCache.gcInterval = Duration.zero;
+    InfiniteQuery.disposalDelay = Duration.zero;
+  });
+
+  tearDown(() async {
+    InfiniteQuery.disposalDelay = const Duration(seconds: 5);
+    await QueryClient.resetForTesting();
+  });
+
+  testWidgets('exposes infinite pagination commands', (tester) async {
+    UseInfiniteQueryResult<List<int>, int>? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            final fetch = useCallback<Future<List<int>> Function(int page)>(
+              (page) async => [page],
+              const [],
+            );
+            final options = useMemoized(
+              () => InfiniteQueryOptions<List<int>, int>(
+                getNextPageParam: (pages, lastPage) {
+                  if (pages.length >= 2) return null;
+                  return pages.length + 1;
+                },
+              ),
+              const [],
+            );
+            result = useInfiniteQuery<List<int>, int>(
+              'pages'.toQueryKey(),
+              fetch,
+              options: options,
+            );
+            return Text(result!.state.pages.length.toString());
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(result!.state.pages, hasLength(1));
+
+    await result!.fetchNextPage();
+    await tester.pumpAndSettle();
+    expect(result!.state.pages, hasLength(2));
+
+    await result!.refetchPage(0);
+    result!.reset();
+    expect(result!.query.state.pages, isEmpty);
+  });
+}

--- a/packages/fasq_hooks/test/use_mutation_test.dart
+++ b/packages/fasq_hooks/test/use_mutation_test.dart
@@ -4,198 +4,73 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('useMutation', () {
-    testWidgets('executes mutation and updates state', (tester) async {
-      Future<String> createUser(String name) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'User: $name';
-      }
+  setUp(() => QueryCache.gcInterval = Duration.zero);
+  tearDown(() async {
+    await QueryClient.resetForTesting();
+  });
 
-      UseMutationResult<String, String>? capturedResult;
+  testWidgets('returns submission and updates mutation state', (tester) async {
+    UseMutationResult<String, String>? result;
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final mutation = useMutation<String, String>(createUser);
-              capturedResult = mutation;
-
-              return ElevatedButton(
-                onPressed: () => mutation.mutate('John'),
-                child: Text(mutation.data ?? 'Create User'),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            result = useMutation<String, String>(
+              mutationFn: (name) async => 'User: $name',
+            );
+            return ElevatedButton(
+              onPressed: () => result!.mutate('Ada'),
+              child: Text(result!.data ?? 'create'),
+            );
+          },
         ),
-      );
+      ),
+    );
+    await tester.pump();
+    await result!.mutate('Ada');
+    await tester.pump();
+    await tester.pump();
 
-      expect(capturedResult?.isIdle, true);
-      expect(capturedResult?.hasData, false);
+    expect(result!.isSuccess, isTrue);
+    expect(result!.data, 'User: Ada');
+    final submission = await result!.submit('Grace');
+    expect(submission.isSucceeded, isTrue);
+    expect(submission.data, 'User: Grace');
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+  });
 
-      await tester.tap(find.text('Create User'));
-      await tester.pump();
+  testWidgets('preserves callbacks and stack traces', (tester) async {
+    Object? callbackError;
+    UseMutationResult<String, String>? result;
 
-      expect(capturedResult?.isLoading, true);
-
-      await tester.pumpAndSettle();
-
-      expect(capturedResult?.hasData, true);
-      expect(capturedResult?.data, 'User: John');
-      expect(find.text('User: John'), findsOneWidget);
-    });
-
-    testWidgets('handles errors correctly', (tester) async {
-      Future<String> createUser(String name) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        throw Exception('creation failed');
-      }
-
-      UseMutationResult<String, String>? capturedResult;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final mutation = useMutation<String, String>(createUser);
-              capturedResult = mutation;
-
-              if (mutation.hasError) {
-                return Text('Error: ${mutation.error}');
-              }
-
-              return ElevatedButton(
-                onPressed: () => mutation.mutate('John'),
-                child: const Text('Create User'),
-              );
-            },
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            result = useMutation<String, String>(
+              mutationFn: (_) async => throw StateError('failed'),
+              onError: (error) => callbackError = error,
+            );
+            return ElevatedButton(
+              onPressed: () => result!.mutate('x'),
+              child: const Text('fail'),
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Create User'));
-      await tester.pump();
+    await tester.tap(find.text('fail'));
+    await tester.pumpAndSettle();
 
-      await tester.pumpAndSettle();
-
-      expect(capturedResult?.hasError, true);
-      expect(capturedResult?.error.toString(), contains('creation failed'));
-      expect(find.textContaining('Error:'), findsOneWidget);
-    });
-
-    testWidgets('calls onSuccess callback', (tester) async {
-      String? successResult;
-
-      Future<String> createUser(String name) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'User: $name';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final mutation = useMutation<String, String>(
-                createUser,
-                onSuccess: (data) {
-                  successResult = data;
-                },
-              );
-
-              return ElevatedButton(
-                onPressed: () => mutation.mutate('Alice'),
-                child: const Text('Create'),
-              );
-            },
-          ),
-        ),
-      );
-
-      await tester.tap(find.text('Create'));
-      await tester.pumpAndSettle();
-
-      expect(successResult, 'User: Alice');
-    });
-
-    testWidgets('calls onError callback', (tester) async {
-      Object? errorResult;
-
-      Future<String> createUser(String name) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        throw Exception('creation failed');
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final mutation = useMutation<String, String>(
-                createUser,
-                onError: (error) {
-                  errorResult = error;
-                },
-              );
-
-              return ElevatedButton(
-                onPressed: () => mutation.mutate('Bob'),
-                child: const Text('Create'),
-              );
-            },
-          ),
-        ),
-      );
-
-      await tester.tap(find.text('Create'));
-      await tester.pumpAndSettle();
-
-      expect(errorResult, isNotNull);
-      expect(errorResult.toString(), contains('creation failed'));
-    });
-
-    // testWidgets('reset clears mutation state', (tester) async {
-    //   Future<String> createUser(String name) async {
-    //     await Future.delayed(const Duration(milliseconds: 100));
-    //     return 'User: $name';
-    //   }
-    //
-    //   MutationState<String, String>? capturedResult;
-    //
-    //   await tester.pumpWidget(
-    //     MaterialApp(
-    //       home: HookBuilder(
-    //         builder: (context) {
-    //           final mutation = useMutation<String, String>(createUser);
-    //           capturedResult = mutation;
-    //
-    //           return Column(
-    //             children: [
-    //               ElevatedButton(
-    //                 onPressed: () => mutation.mutate('Charlie'),
-    //                 child: const Text('Create'),
-    //               ),
-    //               ElevatedButton(
-    //                 onPressed: mutation.reset,
-    //                 child: const Text('Reset'),
-    //               ),
-    //               Text(mutation.data ?? 'no data'),
-    //             ],
-    //           );
-    //         },
-    //       ),
-    //     ),
-    //   );
-    //
-    //   await tester.tap(find.text('Create'));
-    //   await tester.pumpAndSettle();
-    //
-    //   expect(capturedResult?.hasData, true);
-    //   expect(find.text('User: Charlie'), findsOneWidget);
-    //
-    //   await tester.tap(find.text('Reset'));
-    //   await tester.pump();
-    //
-    //   expect(capturedResult?.isIdle, true);
-    //   expect(capturedResult?.hasData, false);
-    //   expect(find.text('no data'), findsOneWidget);
-    // });
+    expect(result!.isError, isTrue);
+    expect(result!.stackTrace, isNotNull);
+    expect(callbackError, isA<StateError>());
+    result!.reset();
+    expect(result!.mutation.state.isIdle, isTrue);
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
   });
 }

--- a/packages/fasq_hooks/test/use_prefetch_test.dart
+++ b/packages/fasq_hooks/test/use_prefetch_test.dart
@@ -4,148 +4,56 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('usePrefetchQuery', () {
-    testWidgets('returns stable callback', (tester) async {
-      late void Function(QueryKey, Future<String> Function(),
-          {QueryOptions? options}) prefetch1;
-      late void Function(QueryKey, Future<String> Function(),
-          {QueryOptions? options}) prefetch2;
+  setUp(() => QueryCache.gcInterval = Duration.zero);
+  tearDown(() async => QueryClient.resetForTesting());
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              prefetch1 = usePrefetchQuery<String>();
-              prefetch2 = usePrefetchQuery<String>();
-              return const SizedBox();
-            },
-          ),
+  testWidgets('prefetch callback returns a future', (tester) async {
+    Future<void> Function(
+      QueryKey,
+      Future<String> Function(), {
+      QueryOptions? options,
+    })?
+    prefetch;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            prefetch = usePrefetchQuery<String>();
+            return const SizedBox();
+          },
         ),
-      );
+      ),
+    );
 
-      await tester.pump();
-
-      expect(prefetch1, equals(prefetch2));
-    });
-
-    testWidgets('prefetch callback works correctly', (tester) async {
-      late void Function(QueryKey, Future<String> Function(),
-          {QueryOptions? options}) prefetch;
-      int fetchCount = 0;
-
-      Future<String> fetchData() async {
-        fetchCount++;
-        return 'test-data';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              prefetch = usePrefetchQuery<String>();
-              return const SizedBox();
-            },
-          ),
-        ),
-      );
-
-      prefetch('test-key'.toQueryKey(), fetchData);
-      await tester.pump();
-
-      expect(fetchCount, equals(1));
-    });
+    await prefetch!('prefetched'.toQueryKey(), () async => 'value');
+    expect(
+      QueryClient().getQueryData<String>('prefetched'.toQueryKey()),
+      'value',
+    );
   });
 
-  group('usePrefetchOnMount', () {
-    testWidgets('prefetches on mount', (tester) async {
-      int fetchCount = 0;
-
-      Future<String> fetchData() async {
-        fetchCount++;
-        return 'test-data';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              usePrefetchOnMount([
-                PrefetchConfig(
-                    queryKey: 'test-key'.toQueryKey(), queryFn: fetchData),
-              ]);
-              return const SizedBox();
-            },
-          ),
+  testWidgets('prefetches all mount configurations', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            usePrefetchOnMount([
+              PrefetchConfig<String>(
+                queryKey: 'a'.toQueryKey(),
+                queryFn: () async => 'A',
+              ),
+              PrefetchConfig<String>(
+                queryKey: 'b'.toQueryKey(),
+                queryFn: () async => 'B',
+              ),
+            ]);
+            return const SizedBox();
+          },
         ),
-      );
-
-      await tester.pump();
-
-      expect(fetchCount, equals(1));
-    });
-
-    testWidgets('multiple configs prefetch in parallel', (tester) async {
-      int fetchCount1 = 0;
-      int fetchCount2 = 0;
-
-      Future<String> fetchData1() async {
-        fetchCount1++;
-        return 'test-data-1';
-      }
-
-      Future<String> fetchData2() async {
-        fetchCount2++;
-        return 'test-data-2';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              usePrefetchOnMount([
-                PrefetchConfig(
-                    queryKey: 'test-key-1'.toQueryKey(), queryFn: fetchData1),
-                PrefetchConfig(
-                    queryKey: 'test-key-2'.toQueryKey(), queryFn: fetchData2),
-              ]);
-              return const SizedBox();
-            },
-          ),
-        ),
-      );
-
-      await tester.pump();
-
-      expect(fetchCount1, equals(1));
-      expect(fetchCount2, equals(1));
-    });
-
-    testWidgets('does not prefetch on rebuild', (tester) async {
-      int fetchCount = 0;
-
-      Future<String> fetchData() async {
-        fetchCount++;
-        return 'test-data';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              usePrefetchOnMount([
-                PrefetchConfig(
-                    queryKey: 'test-key'.toQueryKey(), queryFn: fetchData),
-              ]);
-              return const SizedBox();
-            },
-          ),
-        ),
-      );
-
-      await tester.pump();
-      await tester.pump();
-
-      expect(fetchCount, equals(1));
-    });
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(QueryClient().getQueryData<String>('a'.toQueryKey()), 'A');
+    expect(QueryClient().getQueryData<String>('b'.toQueryKey()), 'B');
   });
 }

--- a/packages/fasq_hooks/test/use_queries_test.dart
+++ b/packages/fasq_hooks/test/use_queries_test.dart
@@ -1,551 +1,78 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fasq_hooks/fasq_hooks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('useQueries', () {
-    setUp(() async {
-      await QueryClient.resetForTesting();
-    });
+  setUp(() {
+    Query.disposalDelay = Duration.zero;
+    QueryCache.gcInterval = Duration.zero;
+  });
+  tearDown(() async => QueryClient.resetForTesting());
 
-    testWidgets('executes all queries independently', (tester) async {
-      final results = <String>[];
-
-      Future<String> fetchData1() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        results.add('data1');
-        return 'data1';
-      }
-
-      Future<String> fetchData2() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        results.add('data2');
-        return 'data2';
-      }
-
-      Future<String> fetchData3() async {
-        await Future.delayed(const Duration(milliseconds: 75));
-        results.add('data3');
-        return 'data3';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
+  testWidgets('returns rich results for parallel queries', (tester) async {
+    List<UseQueryResult<dynamic>>? results;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
           builder: (context) {
-            final queries = useQueries([
-              QueryConfig('query1'.toQueryKey(), fetchData1),
-              QueryConfig('query2'.toQueryKey(), fetchData2),
-              QueryConfig('query3'.toQueryKey(), fetchData3),
+            final fetchOne = useCallback<Future<String> Function()>(
+              () async => 'one',
+              const [],
+            );
+            final fetchTwo = useCallback<Future<int> Function()>(
+              () async => 2,
+              const [],
+            );
+            results = useQueries([
+              QueryConfig<String>('one'.toQueryKey(), fetchOne),
+              QueryConfig<int>('two'.toQueryKey(), fetchTwo),
             ]);
-
-            return Column(
-              children: queries
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
+            return Text(
+              results!.map((result) => result.data?.toString() ?? '').join(','),
             );
           },
         ),
-      );
-
-      // Wait for all queries to complete
-      await tester.pumpAndSettle();
-
-      // Verify all queries executed
-      expect(results, contains('data1'));
-      expect(results, contains('data2'));
-      expect(results, contains('data3'));
-
-      // Verify final states
-      // Note: In real usage, we'd access the hook state differently
-      expect(find.text('data1'), findsOneWidget);
-      expect(find.text('data2'), findsOneWidget);
-      expect(find.text('data3'), findsOneWidget);
-    });
-
-    testWidgets('handles config changes correctly', (tester) async {
-      bool useSecondConfig = false;
-
-      Future<String> fetchData1() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'data1';
-      }
-
-      Future<String> fetchData2() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'data2';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final configs = useSecondConfig
-                ? [
-                    QueryConfig('query1'.toQueryKey(), fetchData1),
-                    QueryConfig('query2'.toQueryKey(), fetchData2)
-                  ]
-                : [QueryConfig('query1'.toQueryKey(), fetchData1)];
-
-            final queries = useQueries(configs);
-
-            return Column(
-              children: queries
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Change config
-      useSecondConfig = true;
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      // Should have 2 queries now
-      expect(find.text('data1'), findsOneWidget);
-      expect(find.text('data2'), findsOneWidget);
-    });
-
-    testWidgets('handles errors independently', (tester) async {
-      Future<String> fetchSuccess() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'success';
-      }
-
-      Future<String> fetchError() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        throw Exception('Test error');
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useQueries([
-              QueryConfig('success'.toQueryKey(), fetchSuccess),
-              QueryConfig('error'.toQueryKey(), fetchError),
-            ]);
-
-            return Column(
-              children: [
-                Text(queries[0].hasError
-                    ? 'error'
-                    : queries[0].data?.toString() ?? 'loading'),
-                Text(queries[1].hasError
-                    ? 'error'
-                    : queries[1].data?.toString() ?? 'loading'),
-              ],
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // First query should succeed, second should fail
-      expect(find.text('success'), findsOneWidget);
-      expect(find.text('error'), findsOneWidget);
-    });
-
-    testWidgets('properly cleans up on unmount', (tester) async {
-      Future<String> fetchData(String key) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'data';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useQueries([
-              QueryConfig('query1'.toQueryKey(), () => fetchData('query1')),
-              QueryConfig('query2'.toQueryKey(), () => fetchData('query2')),
-            ]);
-
-            return Column(
-              children: queries
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Unmount widget
-      await tester.pumpWidget(const SizedBox());
-
-      // Wait a bit to ensure cleanup happens
-      await tester.pump(const Duration(milliseconds: 200));
-
-      // Verify queries are cleaned up (no memory leaks)
-      final client = QueryClient();
-      expect(client.hasQuery('query1'.toQueryKey()), isFalse);
-      expect(client.hasQuery('query2'.toQueryKey()), isFalse);
-    });
-
-    testWidgets('updates states independently', (tester) async {
-      int updateCount = 0;
-
-      Future<String> fetchData1() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'data1';
-      }
-
-      Future<String> fetchData2() async {
-        await Future.delayed(const Duration(milliseconds: 200));
-        return 'data2';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useQueries([
-              QueryConfig('query1'.toQueryKey(), fetchData1),
-              QueryConfig('query2'.toQueryKey(), fetchData2),
-            ]);
-
-            updateCount++;
-
-            return Column(
-              children: queries
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      // Should rebuild as queries complete independently
-      await tester.pump(const Duration(milliseconds: 150));
-      expect(find.text('data1'), findsOneWidget);
-      expect(find.text('loading'), findsOneWidget);
-
-      await tester.pump(const Duration(milliseconds: 100));
-      expect(find.text('data1'), findsOneWidget);
-      expect(find.text('data2'), findsOneWidget);
-
-      // Should have rebuilt multiple times as states updated
-      expect(updateCount, greaterThan(1));
-    });
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(results!.map((result) => result.data).toList(), ['one', 2]);
   });
 
-  group('useNamedQueries', () {
-    setUp(() async {
-      await QueryClient.resetForTesting();
-    });
-
-    testWidgets('executes all named queries independently', (tester) async {
-      final results = <String>[];
-
-      Future<String> fetchUsers() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        results.add('users');
-        return 'users';
-      }
-
-      Future<String> fetchPosts() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        results.add('posts');
-        return 'posts';
-      }
-
-      Future<String> fetchComments() async {
-        await Future.delayed(const Duration(milliseconds: 75));
-        results.add('comments');
-        return 'comments';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useNamedQueries([
-              NamedQueryConfig(
-                  name: 'users',
-                  queryKey: 'users'.toQueryKey(),
-                  queryFn: fetchUsers),
-              NamedQueryConfig(
-                  name: 'posts',
-                  queryKey: 'posts'.toQueryKey(),
-                  queryFn: fetchPosts),
-              NamedQueryConfig(
-                  name: 'comments',
-                  queryKey: 'comments'.toQueryKey(),
-                  queryFn: fetchComments),
-            ]);
-
-            return Column(
-              children: [
-                Text(queries['users']?.data?.toString() ?? 'loading'),
-                Text(queries['posts']?.data?.toString() ?? 'loading'),
-                Text(queries['comments']?.data?.toString() ?? 'loading'),
-              ],
-            );
-          },
+  testWidgets('reconciles named query changes with the same length', (
+    tester,
+  ) async {
+    var useSecond = false;
+    Map<String, UseQueryResult<dynamic>>? results;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) => HookBuilder(
+            builder: (context) {
+              final fetch = useCallback<Future<String> Function()>(
+                () async => useSecond ? 'second' : 'first',
+                [useSecond],
+              );
+              results = useNamedQueries([
+                NamedQueryConfig<String>(
+                  name: 'primary',
+                  queryKey: (useSecond ? 'second' : 'first').toQueryKey(),
+                  queryFn: fetch,
+                ),
+              ]);
+              return ElevatedButton(
+                onPressed: () => setState(() => useSecond = true),
+                child: Text(results!['primary']?.data?.toString() ?? 'load'),
+              );
+            },
+          ),
         ),
-      );
-
-      // Wait for all queries to complete
-      await tester.pumpAndSettle();
-
-      // Verify all queries executed
-      expect(results, contains('users'));
-      expect(results, contains('posts'));
-      expect(results, contains('comments'));
-
-      // Verify final states
-      expect(find.text('users'), findsOneWidget);
-      expect(find.text('posts'), findsOneWidget);
-      expect(find.text('comments'), findsOneWidget);
-    });
-
-    testWidgets('handles config changes correctly', (tester) async {
-      bool useSecondConfig = false;
-
-      Future<String> fetchUsers() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'users';
-      }
-
-      Future<String> fetchPosts() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'posts';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final configs = useSecondConfig
-                ? [
-                    NamedQueryConfig(
-                        name: 'users',
-                        queryKey: 'users'.toQueryKey(),
-                        queryFn: fetchUsers),
-                    NamedQueryConfig(
-                        name: 'posts',
-                        queryKey: 'posts'.toQueryKey(),
-                        queryFn: fetchPosts),
-                  ]
-                : [
-                    NamedQueryConfig(
-                        name: 'users',
-                        queryKey: 'users'.toQueryKey(),
-                        queryFn: fetchUsers),
-                  ];
-
-            final queries = useNamedQueries(configs);
-
-            return Column(
-              children: queries.entries
-                  .map((entry) => Text(
-                      '${entry.key}: ${entry.value.data?.toString() ?? 'loading'}'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Change config
-      useSecondConfig = true;
-      await tester.pump();
-      await tester.pumpAndSettle();
-
-      // Should have 2 queries now
-      expect(find.text('users: users'), findsOneWidget);
-      expect(find.text('posts: posts'), findsOneWidget);
-    });
-
-    testWidgets('handles errors independently', (tester) async {
-      Future<String> fetchSuccess() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'success';
-      }
-
-      Future<String> fetchError() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        throw Exception('Test error');
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useNamedQueries([
-              NamedQueryConfig(
-                  name: 'success',
-                  queryKey: 'success'.toQueryKey(),
-                  queryFn: fetchSuccess),
-              NamedQueryConfig(
-                  name: 'error',
-                  queryKey: 'error'.toQueryKey(),
-                  queryFn: fetchError),
-            ]);
-
-            return Column(
-              children: [
-                Text(queries['success']?.hasError == true
-                    ? 'error'
-                    : queries['success']?.data?.toString() ?? 'loading'),
-                Text(queries['error']?.hasError == true
-                    ? 'error'
-                    : queries['error']?.data?.toString() ?? 'loading'),
-              ],
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // First query should succeed, second should fail
-      expect(find.text('success'), findsOneWidget);
-      expect(find.text('error'), findsOneWidget);
-    });
-
-    testWidgets('properly cleans up on unmount', (tester) async {
-      Future<String> fetchData(String key) async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'data';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useNamedQueries([
-              NamedQueryConfig(
-                  name: 'query1',
-                  queryKey: 'query1'.toQueryKey(),
-                  queryFn: () => fetchData('query1')),
-              NamedQueryConfig(
-                  name: 'query2',
-                  queryKey: 'query2'.toQueryKey(),
-                  queryFn: () => fetchData('query2')),
-            ]);
-
-            return Column(
-              children: queries.values
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Unmount widget
-      await tester.pumpWidget(const SizedBox());
-
-      // Wait a bit to ensure cleanup happens
-      await tester.pump(const Duration(milliseconds: 200));
-
-      // Verify queries are cleaned up (no memory leaks)
-      final client = QueryClient();
-      expect(client.hasQuery('query1'.toQueryKey()), isFalse);
-      expect(client.hasQuery('query2'.toQueryKey()), isFalse);
-    });
-
-    testWidgets('updates states independently', (tester) async {
-      int updateCount = 0;
-
-      Future<String> fetchUsers() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'users';
-      }
-
-      Future<String> fetchPosts() async {
-        await Future.delayed(const Duration(milliseconds: 200));
-        return 'posts';
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useNamedQueries([
-              NamedQueryConfig(
-                  name: 'users',
-                  queryKey: 'users'.toQueryKey(),
-                  queryFn: fetchUsers),
-              NamedQueryConfig(
-                  name: 'posts',
-                  queryKey: 'posts'.toQueryKey(),
-                  queryFn: fetchPosts),
-            ]);
-
-            updateCount++;
-
-            return Column(
-              children: queries.values
-                  .map((q) => Text(q.data?.toString() ?? 'loading'))
-                  .toList(),
-            );
-          },
-        ),
-      );
-
-      // Should rebuild as queries complete independently
-      await tester.pump(const Duration(milliseconds: 150));
-      expect(find.text('users'), findsOneWidget);
-      expect(find.text('loading'), findsOneWidget);
-
-      await tester.pump(const Duration(milliseconds: 100));
-      expect(find.text('users'), findsOneWidget);
-      expect(find.text('posts'), findsOneWidget);
-
-      // Should have rebuilt multiple times as states updated
-      expect(updateCount, greaterThan(1));
-    });
-
-    testWidgets('named access works correctly', (tester) async {
-      Future<List<String>> fetchUsers() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return ['user1', 'user2'];
-      }
-
-      Future<Map<String, int>> fetchStats() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return {'count': 42};
-      }
-
-      await tester.pumpWidget(
-        HookBuilder(
-          builder: (context) {
-            final queries = useNamedQueries([
-              NamedQueryConfig(
-                  name: 'users',
-                  queryKey: 'users'.toQueryKey(),
-                  queryFn: fetchUsers),
-              NamedQueryConfig(
-                  name: 'stats',
-                  queryKey: 'stats'.toQueryKey(),
-                  queryFn: fetchStats),
-            ]);
-
-            final usersState = queries['users']!;
-            final statsState = queries['stats']!;
-
-            return Column(
-              children: [
-                Text(usersState.hasData
-                    ? usersState.data!.length.toString()
-                    : 'loading'),
-                Text(statsState.hasData
-                    ? statsState.data!['count'].toString()
-                    : 'loading'),
-              ],
-            );
-          },
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Verify named access works correctly
-      expect(find.text('2'), findsOneWidget); // users length
-      expect(find.text('42'), findsOneWidget); // stats count
-    });
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(results!['primary']!.data, 'first');
+    await tester.tap(find.text('first'));
+    await tester.pumpAndSettle();
+    expect(results!['primary']!.data, 'second');
   });
 }

--- a/packages/fasq_hooks/test/use_query_test.dart
+++ b/packages/fasq_hooks/test/use_query_test.dart
@@ -4,186 +4,137 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  setUp(() {
+    Query.disposalDelay = Duration.zero;
+    QueryCache.gcInterval = Duration.zero;
+  });
+
   tearDown(() async {
+    Query.disposalDelay = const Duration(seconds: 5);
     await QueryClient.resetForTesting();
   });
 
-  group('useQuery', () {
-    testWidgets('fetches data and updates state', (tester) async {
-      Future<String> fetchData() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'test data';
-      }
+  testWidgets('returns state and query commands', (tester) async {
+    var calls = 0;
+    UseQueryResult<String>? result;
 
-      QueryState<String>? capturedState;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            final fetch = useCallback<Future<String> Function()>(() async {
+              calls++;
+              return 'hello $calls';
+            }, const []);
+            result = useQuery<String>('greeting'.toQueryKey(), queryFn: fetch);
+            return Text(result!.data ?? 'loading');
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
+    expect(result!.data, 'hello 1');
+    expect(result!.isSuccess, isTrue);
+
+    result!.setData('manual');
+    await tester.pumpAndSettle();
+    expect(result!.data, 'manual');
+
+    await result!.refetch();
+    await tester.pump();
+    expect(result!.data, 'hello 2');
+  });
+
+  testWidgets('supports token fetchers and dependency keys', (tester) async {
+    UseQueryResult<String>? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            final fetch =
+                useCallback<Future<String> Function(CancellationToken token)>((
+                  receivedToken,
+                ) async {
+                  expect(receivedToken, isA<CancellationToken>());
+                  return 'token-result';
+                }, const []);
+            result = useQuery<String>(
+              'child'.toQueryKey(),
+              queryFnWithToken: fetch,
+              dependsOn: 'parent'.toQueryKey(),
+            );
+            return Text(result!.data ?? 'loading');
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(result!.data, 'token-result');
+  });
+
+  testWidgets('reconfigures the same query instance', (tester) async {
+    var version = 1;
+    UseQueryResult<String>? result;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) => HookBuilder(
             builder: (context) {
-              final state = useQuery('test-key'.toQueryKey(), fetchData);
-              capturedState = state;
-              return Text(state.data ?? 'loading');
-            },
-          ),
-        ),
-      );
-
-      expect(capturedState?.isLoading, true);
-      expect(capturedState?.hasData, false);
-
-      await tester.pumpAndSettle();
-
-      expect(capturedState?.hasData, true);
-      expect(capturedState?.data, 'test data');
-      expect(find.text('test data'), findsOneWidget);
-    });
-
-    testWidgets('handles errors correctly', (tester) async {
-      Future<String> fetchData() async {
-        await Future.delayed(const Duration(milliseconds: 100));
-        throw Exception('fetch failed');
-      }
-
-      QueryState<String>? capturedState;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final state = useQuery('test-error'.toQueryKey(), fetchData);
-              capturedState = state;
-
-              if (state.hasError) {
-                return Text('error: ${state.error}');
-              }
-              return const Text('loading');
-            },
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      expect(capturedState?.hasError, true);
-      expect(capturedState?.error.toString(), contains('fetch failed'));
-      expect(find.textContaining('error:'), findsOneWidget);
-    });
-
-    testWidgets('shares query across widgets with same key', (tester) async {
-      var fetchCount = 0;
-
-      Future<String> fetchData() async {
-        fetchCount++;
-        await Future.delayed(const Duration(milliseconds: 100));
-        return 'shared data';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Column(
-            children: [
-              HookBuilder(
-                builder: (context) {
-                  final queryKey = 'shared-key'.toQueryKey();
-                  final state = useQuery(queryKey, fetchData);
-                  return Text('Widget1: ${state.data ?? "loading"}');
-                },
-              ),
-              HookBuilder(
-                builder: (context) {
-                  final queryKey = 'shared-key'.toQueryKey();
-                  final state = useQuery(queryKey, fetchData);
-                  return Text('Widget2: ${state.data ?? "loading"}');
-                },
-              ),
-            ],
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      expect(fetchCount, 1);
-      expect(find.text('Widget1: shared data'), findsOneWidget);
-      expect(find.text('Widget2: shared data'), findsOneWidget);
-    });
-
-    testWidgets('resubscribes when key changes', (tester) async {
-      var key = 'key1'.toQueryKey();
-
-      Future<String> fetchData() async {
-        await Future.delayed(const Duration(milliseconds: 50));
-        return 'data for ${key.key}';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: StatefulBuilder(
-            builder: (context, setState) {
-              return HookBuilder(
-                builder: (context) {
-                  final state = useQuery(key, fetchData);
-
-                  return Column(
-                    children: [
-                      Text(state.data ?? 'loading'),
-                      ElevatedButton(
-                        onPressed: () {
-                          setState(() => key = 'key2'.toQueryKey());
-                        },
-                        child: const Text('Change Key'),
-                      ),
-                    ],
-                  );
-                },
+              final fetch = useCallback<Future<String> Function()>(
+                () async => 'version $version',
+                [version],
+              );
+              result = useQuery<String>(
+                'versioned'.toQueryKey(),
+                queryFn: fetch,
+              );
+              return Column(
+                children: [
+                  Text(result!.data ?? 'loading'),
+                  ElevatedButton(
+                    onPressed: () => setState(() => version = 2),
+                    child: const Text('change'),
+                  ),
+                ],
               );
             },
           ),
         ),
-      );
+      ),
+    );
+    await tester.pumpAndSettle();
+    final query = result!.query;
+    expect(result!.data, 'version 1');
 
-      await tester.pumpAndSettle();
-      expect(find.text('data for key1'), findsOneWidget);
+    await tester.tap(find.text('change'));
+    await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Change Key'));
-      await tester.pump();
-      await tester.pumpAndSettle();
+    expect(identical(result!.query, query), isTrue);
+    expect(result!.data, 'version 2');
+  });
 
-      expect(find.text('data for key2'), findsOneWidget);
-    });
-
-    testWidgets('cleans up subscription on disposal', (tester) async {
-      Future<String> fetchData() async {
-        return 'test data';
-      }
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: HookBuilder(
-            builder: (context) {
-              final queryKey = 'disposal-test'.toQueryKey();
-              final state = useQuery(queryKey, fetchData);
-              return Text(state.data ?? 'loading');
-            },
-          ),
+  testWidgets('cancels and removes a query', (tester) async {
+    UseQueryResult<String>? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HookBuilder(
+          builder: (context) {
+            final fetch = useCallback<Future<String> Function()>(
+              () async => 'data',
+              const [],
+            );
+            result = useQuery<String>('remove-me'.toQueryKey(), queryFn: fetch);
+            return const SizedBox();
+          },
         ),
-      );
-
-      await tester.pumpAndSettle();
-
-      final queryKey = 'disposal-test'.toQueryKey();
-      final queryBefore = QueryClient().getQueryByKey(queryKey);
-      expect(queryBefore, isNotNull);
-      expect(queryBefore?.referenceCount, greaterThan(0));
-
-      await tester.pumpWidget(const MaterialApp(home: Text('empty')));
-      await tester.pumpAndSettle();
-
-      await Future.delayed(const Duration(seconds: 6));
-
-      final queryAfter = QueryClient().getQueryByKey(queryKey);
-      expect(queryAfter, isNull);
-    });
+      ),
+    );
+    await tester.pumpAndSettle();
+    result!.cancel();
+    result!.remove();
+    expect(result!.client.hasQuery('remove-me'.toQueryKey()), isFalse);
   });
 }


### PR DESCRIPTION
## Summary

- Add core query and infinite-query reconfiguration while preserving instances, state, cache, and listeners.
- Add shared durable mutation construction and explicit runtime/client ownership.
- Add rich useQuery, useInfiniteQuery, useMutation, multi-query, prefetch, runtime, and mutation-queue APIs.
- Add parity tests for query actions, pagination, reconfiguration, mutations, multi-query reconciliation, and prefetching.

## Verification

- flutter test packages/fasq_hooks/test packages/fasq/test/client/query_reconfigure_test.dart --reporter compact
- flutter analyze packages/fasq_hooks/lib packages/fasq_hooks/test packages/fasq_hooks/example/lib

README and package version files are intentionally unchanged.