### PR TITLE
feat(core): Add query reconfiguration and mutation factory

### DIFF
--- a/packages/fasq/lib/fasq.dart
+++ b/packages/fasq/lib/fasq.dart
@@ -27,6 +27,7 @@ export 'src/mutation/durable_mutation_catalog.dart';
 export 'src/mutation/durable_mutation_definition.dart';
 export 'src/mutation/durable_mutation_queue.dart';
 export 'src/mutation/mutation.dart';
+export 'src/mutation/mutation_factory.dart';
 export 'src/mutation/mutation_contract.dart';
 export 'src/mutation/mutation_meta.dart';
 export 'src/mutation/mutation_options.dart';

--- a/packages/fasq/lib/src/cache/query_cache.dart
+++ b/packages/fasq/lib/src/cache/query_cache.dart
@@ -117,6 +117,7 @@ class QueryCache {
   /// this method before disposing a cache or handing its storage to another
   /// owner.
   Future<void> flushPersistence() async {
+    if (persistenceOptions?.enabled != true) return;
     final initFuture = _persistenceInitFuture;
     if (initFuture != null) await initFuture;
 
@@ -1202,7 +1203,7 @@ class QueryCache {
 
   Future<void> _disposePersistenceResources() async {
     final initFuture = _persistenceInitFuture;
-    if (initFuture != null) {
+    if (persistenceOptions?.enabled == true && initFuture != null) {
       try {
         await initFuture;
       } on Object catch (_) {}

--- a/packages/fasq/lib/src/client/internal/query_client_registry.dart
+++ b/packages/fasq/lib/src/client/internal/query_client_registry.dart
@@ -11,15 +11,16 @@ import 'package:fasq/src/query/query_options.dart';
 import 'package:flutter/foundation.dart';
 
 /// Factory used by [QueryClientRegistry] to create [Query] instances.
-typedef QueryClientQueryFactory = Query<T> Function<T>({
-  required QueryKey queryKey,
-  required QueryDependencyManager dependencyManager,
-  required void Function() onDispose,
-  Future<T> Function()? queryFn,
-  Future<T> Function(CancellationToken token)? queryFnWithToken,
-  QueryOptions? options,
-  CacheEntry<T>? initialEntry,
-});
+typedef QueryClientQueryFactory =
+    Query<T> Function<T>({
+      required QueryKey queryKey,
+      required QueryDependencyManager dependencyManager,
+      required void Function() onDispose,
+      Future<T> Function()? queryFn,
+      Future<T> Function(CancellationToken token)? queryFnWithToken,
+      QueryOptions? options,
+      CacheEntry<T>? initialEntry,
+    });
 
 /// Owns in-memory query registries and related lifecycle operations.
 final class QueryClientRegistry {
@@ -27,8 +28,8 @@ final class QueryClientRegistry {
   QueryClientRegistry({
     required QueryCache cache,
     required QueryClientQueryFactory queryFactory,
-  })  : _cache = cache,
-        _queryFactory = queryFactory;
+  }) : _cache = cache,
+       _queryFactory = queryFactory;
 
   final QueryCache _cache;
   final QueryClientQueryFactory _queryFactory;
@@ -96,6 +97,38 @@ final class QueryClientRegistry {
     return query;
   }
 
+  /// Reconfigures a registered query without replacing its instance.
+  Query<T> reconfigureQuery<T>(
+    QueryKey queryKey, {
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+    QueryKey? dependsOn,
+  }) {
+    final existing = _queries[queryKey.key];
+    if (existing == null || existing.isDisposed) {
+      return getQuery<T>(
+        queryKey,
+        queryFn: queryFn,
+        queryFnWithToken: queryFnWithToken,
+        options: options,
+        dependsOn: dependsOn,
+      );
+    }
+    if (dependsOn == null) {
+      _dependencyManager.removeParent(queryKey.key);
+    } else {
+      _dependencyManager.registerDependency(queryKey.key, dependsOn.key);
+    }
+    final query = existing as Query<T>;
+    query.reconfigure(
+      queryFn: queryFn,
+      queryFnWithToken: queryFnWithToken,
+      options: options,
+    );
+    return query;
+  }
+
   /// Gets an existing infinite query or creates a new one.
   InfiniteQuery<TData, TParam> getInfiniteQuery<TData, TParam>(
     QueryKey queryKey,
@@ -124,6 +157,25 @@ final class QueryClientRegistry {
 
     _infiniteQueries[key] = infinite as InfiniteQuery<Object?, Object?>;
     return infinite;
+  }
+
+  /// Reconfigures a registered infinite query without replacing its instance.
+  InfiniteQuery<TData, TParam> reconfigureInfiniteQuery<TData, TParam>(
+    QueryKey queryKey,
+    Future<TData> Function(TParam param) queryFn, {
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    final existing = _infiniteQueries[queryKey.key];
+    if (existing == null || existing.isDisposed) {
+      return getInfiniteQuery<TData, TParam>(
+        queryKey,
+        queryFn,
+        options: options,
+      );
+    }
+    final query = existing as InfiniteQuery<TData, TParam>;
+    query.reconfigure(queryFn: queryFn, options: options);
+    return query;
   }
 
   /// Retrieves an existing query by key.

--- a/packages/fasq/lib/src/client/query_client.dart
+++ b/packages/fasq/lib/src/client/query_client.dart
@@ -310,6 +310,24 @@ class QueryClient with WidgetsBindingObserver {
     );
   }
 
+  /// Reconfigures a query while preserving its identity, state, cache, and
+  /// active listeners.
+  Query<T> reconfigureQuery<T>(
+    QueryKey queryKey, {
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+    QueryKey? dependsOn,
+  }) {
+    return _registry.reconfigureQuery<T>(
+      queryKey,
+      queryFn: queryFn,
+      queryFnWithToken: queryFnWithToken,
+      options: options,
+      dependsOn: dependsOn,
+    );
+  }
+
   /// Gets an existing infinite query or creates a new one.
   InfiniteQuery<TData, TParam> getInfiniteQuery<TData, TParam>(
     QueryKey queryKey,
@@ -317,6 +335,19 @@ class QueryClient with WidgetsBindingObserver {
     InfiniteQueryOptions<TData, TParam>? options,
   }) {
     return _registry.getInfiniteQuery<TData, TParam>(
+      queryKey,
+      queryFn,
+      options: options,
+    );
+  }
+
+  /// Reconfigures an infinite query while preserving its pages and listeners.
+  InfiniteQuery<TData, TParam> reconfigureInfiniteQuery<TData, TParam>(
+    QueryKey queryKey,
+    Future<TData> Function(TParam param) queryFn, {
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    return _registry.reconfigureInfiniteQuery<TData, TParam>(
       queryKey,
       queryFn,
       options: options,
@@ -516,6 +547,7 @@ class QueryClient with WidgetsBindingObserver {
   /// Only use this in tests to get a fresh instance.
   static Future<void> resetForTesting() async {
     Query.disposalDelay = Duration.zero;
+    InfiniteQuery.disposalDelay = Duration.zero;
     QueryCache.gcInterval = Duration.zero;
     QueryCache.persistenceGcInterval = Duration.zero;
 

--- a/packages/fasq/lib/src/mutation/mutation_factory.dart
+++ b/packages/fasq/lib/src/mutation/mutation_factory.dart
@@ -1,0 +1,42 @@
+import 'package:fasq/src/client/query_client.dart';
+import 'package:fasq/src/mutation/durable_mutation_catalog.dart';
+import 'package:fasq/src/mutation/durable_mutation_queue.dart';
+import 'package:fasq/src/mutation/mutation.dart';
+import 'package:fasq/src/mutation/mutation_contract.dart';
+import 'package:fasq/src/mutation/mutation_options.dart';
+
+/// Creates mutations from either ordinary functions or bootstrapped durable
+/// mutation keys.
+final class MutationFactory {
+  const MutationFactory._();
+
+  /// Creates a mutation from a registered durable [key].
+  static Mutation<TData, TVariables> fromKey<TData, TVariables>({
+    required FasqMutationKey<TData, TVariables> key,
+    required DurableMutationCatalog catalog,
+    required DurableMutationQueue queue,
+    QueryClient? client,
+    MutationOptions<TData, TVariables>? options,
+  }) {
+    final definition = catalog.resolve(key);
+    final effectiveOptions = definition.bind(queue, base: options);
+    return Mutation<TData, TVariables>(
+      mutationFn: definition.execute,
+      options: effectiveOptions,
+      client: client,
+    );
+  }
+
+  /// Creates an ordinary non-durable mutation.
+  static Mutation<TData, TVariables> fromFunction<TData, TVariables>({
+    required Future<TData> Function(TVariables variables) mutationFn,
+    QueryClient? client,
+    MutationOptions<TData, TVariables>? options,
+  }) {
+    return Mutation<TData, TVariables>(
+      mutationFn: mutationFn,
+      options: options,
+      client: client,
+    );
+  }
+}

--- a/packages/fasq/lib/src/query/dependency/query_dependency_manager.dart
+++ b/packages/fasq/lib/src/query/dependency/query_dependency_manager.dart
@@ -73,6 +73,20 @@ class QueryDependencyManager {
     }
   }
 
+  /// Removes only the parent relationship for [childKey].
+  ///
+  /// Unlike [unregister], this keeps the query's children intact. It is used
+  /// when an existing query changes its dependency without being disposed.
+  void removeParent(String childKey) {
+    final parent = _childToParent.remove(childKey);
+    if (parent == null) return;
+    final children = _parentToChildren[parent];
+    children?.remove(childKey);
+    if (children?.isEmpty ?? false) {
+      _parentToChildren.remove(parent);
+    }
+  }
+
   /// Returns all direct child keys for a given parent.
   Set<String> getChildren(String parentKey) {
     return Set.unmodifiable(_parentToChildren[parentKey] ?? {});

--- a/packages/fasq/lib/src/query/infinite/infinite_query.dart
+++ b/packages/fasq/lib/src/query/infinite/infinite_query.dart
@@ -57,8 +57,8 @@ class InfiniteQuery<TData, TParam> {
     this.cache,
     this.onDispose,
     List<Page<TData, TParam>>? initialPages,
-  })  : key = queryKey.key,
-        _currentState = InfiniteQueryState<TData, TParam>.idle() {
+  }) : key = queryKey.key,
+       _currentState = InfiniteQueryState<TData, TParam>.idle() {
     if (initialPages != null && initialPages.isNotEmpty) {
       final opts = options;
       final hasNext = _computeHasNextForPages(opts, initialPages);
@@ -82,10 +82,10 @@ class InfiniteQuery<TData, TParam> {
   final String key;
 
   /// Page fetch function invoked with a page parameter.
-  final Future<TData> Function(TParam param) queryFn;
+  Future<TData> Function(TParam param) queryFn;
 
   /// Optional behavior configuration for this infinite query.
-  final InfiniteQueryOptions<TData, TParam>? options;
+  InfiniteQueryOptions<TData, TParam>? options;
 
   /// Optional cache integration used for lifecycle and prefetch behavior.
   final QueryCache? cache;
@@ -100,6 +100,10 @@ class InfiniteQuery<TData, TParam> {
   bool _isDisposed = false;
   Future<void>? _fetchFuture;
   bool _isPrefetching = false;
+  int _operationGeneration = 0;
+
+  /// Delay before an inactive infinite query is disposed.
+  static Duration disposalDelay = const Duration(seconds: 5);
 
   /// Broadcast stream of query state updates.
   Stream<InfiniteQueryState<TData, TParam>> get stream => _controller.stream;
@@ -213,24 +217,29 @@ class InfiniteQuery<TData, TParam> {
   Future<void> fetchNextPage([TParam? overrideParam]) async {
     if (_isDisposed || options?.enabled == false) return;
     if (_fetchFuture != null) return;
-    _fetchFuture = _fetchNextPageImpl(overrideParam);
+    final generation = _operationGeneration;
+    final future = _fetchNextPageImpl(overrideParam, generation);
+    _fetchFuture = future;
     try {
-      await _fetchFuture;
+      await future;
     } finally {
-      _fetchFuture = null;
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
     }
   }
 
-  Future<void> _fetchNextPageImpl([TParam? overrideParam]) async {
-    if (_isDisposed || options?.enabled == false) return;
+  Future<void> _fetchNextPageImpl(
+    TParam? overrideParam,
+    int generation,
+  ) async {
+    if (_isStaleOperation(generation) || options?.enabled == false) return;
     final pages = _currentState.pages;
     final nextParam = overrideParam ?? _computeNextParam(pages);
     if (nextParam == null) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       _updateState(_currentState.copyWith(hasNextPage: false));
       return;
     }
-    if (_isDisposed) return;
+    if (_isStaleOperation(generation)) return;
     _updateState(
       _currentState.copyWith(
         isFetchingNextPage: true,
@@ -239,7 +248,7 @@ class InfiniteQuery<TData, TParam> {
     );
     try {
       final data = await queryFn(nextParam);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final newPage = Page<TData, TParam>(param: nextParam).withData(data);
       final newPages = [...pages, newPage];
       final capped = _applyMaxPages(newPages, dropFromStart: true);
@@ -251,7 +260,7 @@ class InfiniteQuery<TData, TParam> {
       );
       options?.onSuccess?.call();
     } on Object catch (e, s) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final errorPage = Page<TData, TParam>(param: nextParam).withError(e, s);
       final newPages = [...pages, errorPage];
       final capped = _applyMaxPages(newPages, dropFromStart: true);
@@ -300,28 +309,30 @@ class InfiniteQuery<TData, TParam> {
   Future<void> fetchPreviousPage() async {
     if (_isDisposed || options?.enabled == false) return;
     if (_fetchFuture != null) return;
-    _fetchFuture = _fetchPreviousPageImpl();
+    final generation = _operationGeneration;
+    final future = _fetchPreviousPageImpl(generation);
+    _fetchFuture = future;
     try {
-      await _fetchFuture;
+      await future;
     } finally {
-      _fetchFuture = null;
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
     }
   }
 
-  Future<void> _fetchPreviousPageImpl() async {
-    if (_isDisposed || options?.enabled == false) return;
+  Future<void> _fetchPreviousPageImpl(int generation) async {
+    if (_isStaleOperation(generation) || options?.enabled == false) return;
     final pages = _currentState.pages;
     final prevParam = _computePreviousParam(pages);
     if (prevParam == null) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       _updateState(_currentState.copyWith(hasPreviousPage: false));
       return;
     }
-    if (_isDisposed) return;
+    if (_isStaleOperation(generation)) return;
     _updateState(_currentState.copyWith(isFetchingPreviousPage: true));
     try {
       final data = await queryFn(prevParam);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final newPage = Page<TData, TParam>(param: prevParam).withData(data);
       final newPages = [newPage, ...pages];
       final capped = _applyMaxPages(newPages, dropFromStart: false);
@@ -333,7 +344,7 @@ class InfiniteQuery<TData, TParam> {
       );
       options?.onSuccess?.call();
     } on Object catch (e, s) {
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final errorPage = Page<TData, TParam>(param: prevParam).withError(e, s);
       final newPages = [errorPage, ...pages];
       final capped = _applyMaxPages(newPages, dropFromStart: false);
@@ -376,12 +387,27 @@ class InfiniteQuery<TData, TParam> {
     if (_fetchFuture != null) return;
     final pages = _currentState.pages;
     if (index < 0 || index >= pages.length) return;
+    final generation = _operationGeneration;
     final page = pages[index];
+    final future = _refetchPageImpl(index, page, generation);
+    _fetchFuture = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_fetchFuture, future)) _fetchFuture = null;
+    }
+  }
+
+  Future<void> _refetchPageImpl(
+    int index,
+    Page<TData, TParam> page,
+    int generation,
+  ) async {
     try {
       final data = await queryFn(page.param);
-      if (_isDisposed) return;
+      if (_isStaleOperation(generation)) return;
       final updated = page.withData(data);
-      final newPages = [...pages];
+      final newPages = [..._currentState.pages];
       newPages[index] = updated;
       _updateStateWithPages(
         newPages,
@@ -389,13 +415,13 @@ class InfiniteQuery<TData, TParam> {
         dataUpdatedAt: DateTime.now(),
       );
       options?.onSuccess?.call();
-    } on Object catch (e, s) {
-      if (_isDisposed) return;
-      final updated = page.withError(e, s);
-      final newPages = [...pages];
+    } on Object catch (error, stackTrace) {
+      if (_isStaleOperation(generation)) return;
+      final updated = page.withError(error, stackTrace);
+      final newPages = [..._currentState.pages];
       newPages[index] = updated;
       _updateStateWithPages(newPages);
-      options?.onError?.call(e);
+      options?.onError?.call(error);
     }
   }
 
@@ -410,6 +436,7 @@ class InfiniteQuery<TData, TParam> {
   /// query.reset();
   /// ```
   void reset() {
+    _operationGeneration++;
     _fetchFuture = null;
     _updateState(InfiniteQueryState<TData, TParam>.idle());
   }
@@ -438,6 +465,28 @@ class InfiniteQuery<TData, TParam> {
       status: QueryStatus.success,
       dataUpdatedAt: DateTime.now(),
     );
+  }
+
+  /// Replaces the fetch configuration while preserving this query instance,
+  /// pages, state, and listeners.
+  void reconfigure({
+    required Future<TData> Function(TParam param) queryFn,
+    InfiniteQueryOptions<TData, TParam>? options,
+  }) {
+    _operationGeneration++;
+    _fetchFuture = null;
+    this.queryFn = queryFn;
+    this.options = options;
+    _updateState(
+      _currentState.copyWith(
+        hasNextPage: _computeHasNext(_currentState.pages),
+        hasPreviousPage: _computeHasPrev(_currentState.pages),
+      ),
+    );
+  }
+
+  bool _isStaleOperation(int generation) {
+    return _isDisposed || generation != _operationGeneration;
   }
 
   void _updateState(InfiniteQueryState<TData, TParam> newState) {
@@ -560,7 +609,11 @@ class InfiniteQuery<TData, TParam> {
   }
 
   void _scheduleDisposal() {
-    _disposeTimer = Timer(const Duration(seconds: 5), () {
+    if (disposalDelay == Duration.zero) {
+      if (_referenceCount == 0) dispose();
+      return;
+    }
+    _disposeTimer = Timer(disposalDelay, () {
       if (_referenceCount == 0) {
         dispose();
       }

--- a/packages/fasq/lib/src/query/query.dart
+++ b/packages/fasq/lib/src/query/query.dart
@@ -95,15 +95,15 @@ class Query<T> {
     this.dependencyManager,
     this.onDispose,
     CacheEntry<T>? initialEntry,
-  })  : assert(
-          queryFn != null || queryFnWithToken != null,
-          'Either queryFn or queryFnWithToken must be provided',
-        ),
-        key = queryKey.key,
-        _currentState = QueryState<T>.idle(),
-        _debugCreationStack = kDebugMode ? StackTrace.current : null,
-        _debugHolders = kDebugMode ? <Object, StackTrace>{} : null,
-        _debugHolderOrder = kDebugMode ? <Object>[] : null {
+  }) : assert(
+         queryFn != null || queryFnWithToken != null,
+         'Either queryFn or queryFnWithToken must be provided',
+       ),
+       key = queryKey.key,
+       _currentState = QueryState<T>.idle(),
+       _debugCreationStack = kDebugMode ? StackTrace.current : null,
+       _debugHolders = kDebugMode ? <Object, StackTrace>{} : null,
+       _debugHolderOrder = kDebugMode ? <Object>[] : null {
     _controller = StreamController<QueryState<T>>.broadcast();
 
     // Set initial state based on cache snapshot and staleness
@@ -120,17 +120,17 @@ class Query<T> {
   /// The async function that fetches the data.
   ///
   /// // TODO(fasq): Deprecate in favor of queryFnWithToken in next major version
-  final Future<T> Function()? queryFn;
+  Future<T> Function()? queryFn;
 
   /// The async function that fetches data with cancellation support.
   ///
   /// Use this instead of [queryFn] to enable cooperative cancellation.
   /// The [CancellationToken] can be checked during long operations or passed
   /// to HTTP clients that support cancellation.
-  final Future<T> Function(CancellationToken token)? queryFnWithToken;
+  Future<T> Function(CancellationToken token)? queryFnWithToken;
 
   /// Optional configuration for this query.
-  final QueryOptions? options;
+  QueryOptions? options;
 
   /// The cache instance for storing results.
   final QueryCache? cache;
@@ -275,10 +275,10 @@ class Query<T> {
 
   /// Get performance metrics for this query
   QueryMetrics get metrics => QueryMetrics(
-        fetchHistory: List.from(_fetchHistory),
-        lastFetchDuration: _lastFetchDuration,
-        referenceCount: _referenceCount,
-      );
+    fetchHistory: List.from(_fetchHistory),
+    lastFetchDuration: _lastFetchDuration,
+    referenceCount: _referenceCount,
+  );
 
   /// Creates a query function that can be used with _executeFetch.
   ///
@@ -311,11 +311,11 @@ class Query<T> {
       final estimatedSize = _estimateDataFootprint(data);
       if (estimatedSize >= threshold) {
         try {
-          final transformed =
-              await client!.isolatePool.execute<_TransformPayload<T>, T?>(
-            _runDataTransformerTask,
-            _TransformPayload<T>(data: data, transformer: transformer),
-          );
+          final transformed = await client!.isolatePool
+              .execute<_TransformPayload<T>, T?>(
+                _runDataTransformerTask,
+                _TransformPayload<T>(data: data, transformer: transformer),
+              );
           if (transformed != null) {
             return transformed;
           }
@@ -672,6 +672,25 @@ class Query<T> {
     );
   }
 
+  /// Replaces the executable configuration while preserving this query's
+  /// cache, state, listeners, and identity.
+  void reconfigure({
+    Future<T> Function()? queryFn,
+    Future<T> Function(CancellationToken token)? queryFnWithToken,
+    QueryOptions? options,
+  }) {
+    if (queryFn == null && queryFnWithToken == null) {
+      throw ArgumentError(
+        'Either queryFn or queryFnWithToken must be provided',
+      );
+    }
+    cancel();
+    this.queryFn = queryFn;
+    this.queryFnWithToken = queryFnWithToken;
+    this.options = options;
+    _updateState(_currentState);
+  }
+
   void _updateState(QueryState<T> newState) {
     _currentState = newState;
     if (!_controller.isClosed) {
@@ -781,8 +800,9 @@ class Query<T> {
     if (manager == null || queryClient == null) return;
 
     manager.notifyParentDisposed(key, (childKey) {
-      final childQuery =
-          queryClient.getQueryByKey<Object>(StringQueryKey(childKey));
+      final childQuery = queryClient.getQueryByKey<Object>(
+        StringQueryKey(childKey),
+      );
       childQuery?.cancel();
     });
   }

--- a/packages/fasq/lib/src/widgets/mutation_builder.dart
+++ b/packages/fasq/lib/src/widgets/mutation_builder.dart
@@ -4,6 +4,7 @@ import 'package:fasq/src/client/query_client.dart';
 import 'package:fasq/src/mutation/durable_mutation_definition.dart';
 import 'package:fasq/src/mutation/durable_mutation_queue.dart';
 import 'package:fasq/src/mutation/mutation.dart';
+import 'package:fasq/src/mutation/mutation_factory.dart';
 import 'package:fasq/src/mutation/mutation_contract.dart';
 import 'package:fasq/src/mutation/mutation_options.dart';
 import 'package:fasq/src/mutation/mutation_snapshot.dart';
@@ -150,11 +151,19 @@ class _MutationBuilderState<T, TVariables>
     _effectiveOptions = durableDefinition == null
         ? widget.options
         : durableDefinition.bind(durableQueue!, base: widget.options);
-    _mutation = Mutation<T, TVariables>(
-      mutationFn: mutationFn,
-      options: _effectiveOptions,
-      client: _client,
-    );
+    _mutation = durableDefinition == null
+        ? MutationFactory.fromFunction<T, TVariables>(
+            mutationFn: mutationFn,
+            options: _effectiveOptions,
+            client: _client,
+          )
+        : MutationFactory.fromKey<T, TVariables>(
+            key: widget.mutationKey!,
+            catalog: FasqProvider.of(context).mutations,
+            queue: durableQueue!,
+            options: widget.options,
+            client: _client,
+          );
     _state = _mutation.state;
 
     _subscription = _mutation.stream.listen((state) {

--- a/packages/fasq/test/client/query_reconfigure_test.dart
+++ b/packages/fasq/test/client/query_reconfigure_test.dart
@@ -1,0 +1,53 @@
+import 'package:fasq/fasq.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    Query.disposalDelay = Duration.zero;
+    InfiniteQuery.disposalDelay = Duration.zero;
+    QueryCache.gcInterval = Duration.zero;
+  });
+
+  tearDown(() async => QueryClient.resetForTesting());
+
+  test('reconfigures a standard query in place', () async {
+    final client = QueryClient();
+    final key = 'reconfigure'.toQueryKey();
+    final query = client.getQuery<String>(
+      key,
+      queryFn: () async => 'old',
+    );
+    query.addListener();
+    await query.fetch(forceRefetch: true);
+
+    final reconfigured = client.reconfigureQuery<String>(
+      key,
+      queryFn: () async => 'new',
+    );
+    expect(identical(reconfigured, query), isTrue);
+    await reconfigured.fetch(forceRefetch: true);
+    expect(reconfigured.state.data, 'new');
+  });
+
+  test('reconfigures an infinite query in place', () async {
+    final client = QueryClient();
+    final key = 'infinite-reconfigure'.toQueryKey();
+    final query = client.getInfiniteQuery<List<int>, int>(
+      key,
+      (page) async => [page],
+      options: InfiniteQueryOptions<List<int>, int>(
+        getNextPageParam: (pages, last) => pages.length < 1 ? 1 : null,
+      ),
+    );
+    await query.addListener();
+    await query.fetchNextPage();
+
+    final reconfigured = client.reconfigureInfiniteQuery<List<int>, int>(
+      key,
+      (page) async => [page + 10],
+    );
+    expect(identical(reconfigured, query), isTrue);
+    await reconfigured.refetchPage(0);
+    expect(reconfigured.state.pages.single.data, [11]);
+  });
+}


### PR DESCRIPTION
## Summary

- Add QueryClient query and infinite-query reconfiguration APIs.
- Preserve query instances, cache, state, listeners, and dependency relationships while replacing configuration.
- Add shared MutationFactory for ordinary and durable mutations.
- Fix infinite-query operation invalidation and non-persistent cache disposal.

## Verification

- flutter test packages/fasq/test/client/query_reconfigure_test.dart --reporter compact
- Relevant core changes compile through the hooks parity suite.